### PR TITLE
Add astoycos to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,3 +3,4 @@
 approvers:
   - abhiraut
   - rikatz
+  - astoycos

--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -12,3 +12,4 @@
 
 abhiraut
 rikatz
+astoycos


### PR DESCRIPTION
Relating to https://github.com/kubernetes/org/issues/2678 add myself to both the OWNERS
and SECURITY_CONTACTS for the network-policy-api
repository.

Signed-off-by: Andrew Stoycos <astoycos@redhat.com>