### PR TITLE
first pass at scripts for prow precommit and crd jobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,12 @@ vet: ## Run go vet against code.
 
 all: generate manifests fmt vet ## Runs all the development targets
 
+verify:
+	hack/verify-all.sh -v
+
+crd-e2e:
+	hack/e2e-crd.sh -v
+
 ##@ Deployment
 install: manifests ## Install CRDs into the K8s cluster specified in ~/.kube/config.
 	kubectl kustomize config/crd | kubectl apply -f -

--- a/hack/e2e-crd.sh
+++ b/hack/e2e-crd.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+readonly GO111MODULE="on"
+readonly GOFLAGS="-mod=readonly"
+readonly GOPATH="$(mktemp -d)"
+readonly CLUSTER_NAME="verify-network-policy-api"
+readonly ADMISSION_WEBHOOK_VERSION="v0.5.1"
+
+export KUBECONFIG="${GOPATH}/.kubeconfig"
+export GOFLAGS GO111MODULE GOPATH
+export PATH="${GOPATH}/bin:${PATH}"
+
+# Cleanup logic for cleanup on exit
+CLEANED_UP=false
+cleanup() {
+  if [ "$CLEANED_UP" = "true" ]; then
+    return
+  fi
+
+  if [ "${KIND_CREATE_ATTEMPTED:-}" = true ]; then
+    kind delete cluster --name "${CLUSTER_NAME}" || true
+  fi
+  CLEANED_UP=true
+}
+
+trap cleanup INT TERM
+
+# For exit code
+res=0
+
+# Install kind
+(cd $GOPATH && go install sigs.k8s.io/kind@v0.17.0) || res=$?
+
+# Create cluster
+KIND_CREATE_ATTEMPTED=true
+kind create cluster --name "${CLUSTER_NAME}" || res=$?
+
+for KUST_FOLDER in bases patches; do
+  go run sigs.k8s.io/controller-tools/cmd/controller-gen rbac:roleName=manager-role crd paths=./apis/... output:crd:dir=./config/crd/bases output:stdout || res=$?
+  kubectl kustomize config/crd | kubectl apply -f - || res=$?
+  # make install || res=$?
+
+  # Temporary workaround for https://github.com/kubernetes/kubernetes/issues/104090
+  sleep 8
+
+done
+
+# Clean up and exit
+cleanup || res=$?
+exit $res

--- a/hack/kube-env.sh
+++ b/hack/kube-env.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Some useful colors.
+if [[ -z "${color_start-}" ]]; then
+  declare -r color_start="\033["
+  declare -r color_red="${color_start}0;31m"
+  declare -r color_yellow="${color_start}0;33m"
+  declare -r color_green="${color_start}0;32m"
+  declare -r color_norm="${color_start}0m"
+fi
+
+# Returns the server version as MMmmpp, with MM as the major
+# component, mm the minor component, and pp as the patch
+# revision. e.g. 0.7.1 is echoed as 701, and 1.0.11 would be
+# 10011. (This makes for easy integer comparison in bash.)
+function kube_server_version() {
+  local server_version
+  local major
+  local minor
+  local patch
+
+  # This sed expression is the POSIX BRE to match strings like:
+  # Server Version: &version.Info{Major:"0", Minor:"7+", GitVersion:"v0.7.0-dirty", GitCommit:"ad44234f7152e9c66bc2853575445c7071335e57", GitTreeState:"dirty"}
+  # and capture the GitVersion portion (which has the patch level)
+  server_version=$(${KUBECTL} --match-server-version=false version | grep "Server Version:")
+  read major minor patch < <(
+    echo ${server_version} | \
+      sed "s/.*GitVersion:\"v\([0-9]\{1,\}\)\.\([0-9]\{1,\}\)\.\([0-9]\{1,\}\).*/\1 \2 \3/")
+  printf "%02d%02d%02d" ${major} ${minor} ${patch} | sed 's/^0*//'
+}

--- a/hack/verify-all.sh
+++ b/hack/verify-all.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "${SCRIPT_ROOT}/hack/kube-env.sh"
+
+SILENT=true
+
+function is-excluded {
+  for e in $EXCLUDE; do
+    if [[ $1 -ef ${BASH_SOURCE} ]]; then
+      return
+    fi
+    if [[ $1 -ef "$SCRIPT_ROOT/hack/$e" ]]; then
+      return
+    fi
+  done
+  return 1
+}
+
+while getopts ":v" opt; do
+  case $opt in
+    v)
+      SILENT=false
+      ;;
+    \?)
+      echo "Invalid flag: -$OPTARG" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if $SILENT ; then
+  echo "Running in the silent mode, run with -v if you want to see script logs."
+fi
+
+EXCLUDE="verify-all.sh"
+
+ret=0
+for t in `ls $SCRIPT_ROOT/hack/verify-*.sh`
+do
+  if is-excluded $t ; then
+    echo "Skipping $t"
+    continue
+  fi
+  if $SILENT ; then
+    echo -e "Verifying $t"
+    if bash "$t" &> /dev/null; then
+      echo -e "${color_green}SUCCESS${color_norm}"
+    else
+      echo -e "${color_red}FAILED${color_norm}"
+      ret=1
+    fi
+  else
+    if bash "$t"; then
+      echo -e "${color_green}SUCCESS: $t ${color_norm}"
+    else
+      echo -e "${color_red}Test FAILED: $t ${color_norm}"
+      ret=1
+    fi
+  fi
+done
+
+exit $ret
+
+# ex: ts=2 sw=2 et filetype=sh

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+echo "Verifying gofmt"
+
+diff=$(find . -name "*.go" | grep -v "\/vendor\/" | xargs gofmt -s -d 2>&1)
+if [[ -n "${diff}" ]]; then
+  echo "${diff}"
+  echo
+  echo "Please run make fmt to fix the issue(s)"
+  exit 1
+fi
+echo "No issue found"

--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+readonly VERSION="v1.46.2"
+readonly KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+
+cd "${KUBE_ROOT}"
+
+# See configuration file in ${KUBE_ROOT}/.golangci.yml.
+mkdir -p cache
+
+docker run --rm -v $(pwd)/cache:/cache -v $(pwd):/app --security-opt="label=disable" -e GOLANGCI_LINT_CACHE=/cache -w /app "golangci/golangci-lint:$VERSION" golangci-lint run
+
+# ex: ts=2 sw=2 et filetype=sh

--- a/hack/verify-govet.sh
+++ b/hack/verify-govet.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+echo "Verifying govet"
+
+go vet $(go list ./... | grep -v vendor)
+
+echo "Done"


### PR DESCRIPTION
This is to resolve https://github.com/kubernetes-sigs/network-policy-api/issues/37

After chatting with @astoycos we decided it would be better to follow what other sigs have done, and implement a prow job, as well as follow similar patterns for the test scripts (moving to live under hack/).

There will be a second PR for this issue, in test-infra to add the prow job that calls these changes.

p.s. This is my first PR to a kubernetes project, so I'm sure I did something wrong. Please feel free to tell me :). 