### PR TITLE
Add Links to Contributing and Developer Guides in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ You can reach the maintainers of this project at:
 - [Slack](https://kubernetes.slack.com/messages/sig-network-policy-api)
 - [Mailing List](https://groups.google.com/forum/#!forum/kubernetes-sig-network)
 
+To get started contributing please take time to read over the [contributing guidelines](https://github.com/kubernetes-sigs/network-policy-api/blob/master/CONTRIBUTING.md) as well as the [developer guide](https://github.com/kubernetes/community/blob/master/contributors/devel/README.md).
 ### Code of conduct
 
 Participation in the Kubernetes community is governed by the [Kubernetes Code of Conduct](code-of-conduct.md).


### PR DESCRIPTION
solves: #49 

I've added a very small sentence to link to the contributing guidelines and developer guide - is this what you were thinking or would you like additional detail on how to contribute?

Note that the contributing guidelines are also linked when someone (like me!) opens their first PR on the repo. Should we avoid the duplication, or is the link useful before someone gets to the point of creating a PR?

![Screenshot 2022-11-02 at 3 50 52 PM](https://user-images.githubusercontent.com/6361099/199589001-49668619-46c2-4707-ba6d-6b21b19bce5f.png)
