### PR TITLE
bump golangci-lint

### DIFF
--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly VERSION="v1.50.1"
+readonly VERSION="v1.51.2"
 readonly KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 cd "${KUBE_ROOT}"


### PR DESCRIPTION
Might be a fix for https://github.com/kubernetes-sigs/network-policy-api/pull/70