### PR TITLE
Replace k8s.gcr.io with registry.k8s.io

### DIFF
--- a/cmd/cyclonus/cmd/worker/Dockerfile
+++ b/cmd/cyclonus/cmd/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM k8s.gcr.io/e2e-test-images/agnhost:2.36
+FROM registry.k8s.io/e2e-test-images/agnhost:2.36
 
 ENTRYPOINT ["/worker"]
 

--- a/cmd/cyclonus/docs/test-runs.md
+++ b/cmd/cyclonus/docs/test-runs.md
@@ -24,7 +24,7 @@ namespace x).  There are three modes to test network policies in:
 
 Tests can run over multiple protocols and ports.  A typical test run includes protocols TCP and UDP (often
 SCTP as well), and ports 80 and 81.  Each port/protocol combination is served by a container running `agnhost` (docker
-image: k8s.gcr.io/e2e-test-images/agnhost) which is capable of serving a specific protocol on a specific port.  Thus,
+image: registry.k8s.io/e2e-test-images/agnhost) which is capable of serving a specific protocol on a specific port.  Thus,
 if your test includes protocols TCP and UDP, and ports 80 and 81, each pod will have 4 containers.  Named ports are
 included as well -- `serve-80-udp` is the name for port 80 on UDP.
 

--- a/cmd/cyclonus/hack/kind/run-cyclonus.sh
+++ b/cmd/cyclonus/hack/kind/run-cyclonus.sh
@@ -27,8 +27,8 @@ pushd "$CNI"
 popd
 
 # preload agnhost image
-docker pull k8s.gcr.io/e2e-test-images/agnhost:2.36
-kind load docker-image k8s.gcr.io/e2e-test-images/agnhost:2.36 --name "$CLUSTER_NAME"
+docker pull registry.k8s.io/e2e-test-images/agnhost:2.36
+kind load docker-image registry.k8s.io/e2e-test-images/agnhost:2.36 --name "$CLUSTER_NAME"
 
 # make sure that the new kind cluster is the current kubectl context
 kind get clusters

--- a/cmd/cyclonus/pkg/connectivity/probe/pod.go
+++ b/cmd/cyclonus/pkg/connectivity/probe/pod.go
@@ -2,17 +2,18 @@ package probe
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/mattfenwick/collections/pkg/slice"
 	"github.com/mattfenwick/cyclonus/pkg/generator"
 	"github.com/mattfenwick/cyclonus/pkg/kube"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strings"
 )
 
 const (
-	agnhostImage        = "k8s.gcr.io/e2e-test-images/agnhost:2.36"
+	agnhostImage        = "registry.k8s.io/e2e-test-images/agnhost:2.36"
 	cyclonusWorkerImage = "mfenwick100/cyclonus-worker:latest"
 )
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR replaces all `k8s.gcr.io` references with `registry.k8s.io`. See the linked issue for more details.

**Which issue(s) this PR fixes**:
xref https://github.com/kubernetes/k8s.io/issues/4738

**Release note**:
```
Replace all `k8s.gcr.io` references with `registry.k8s.io`
```