### PR TITLE
Fix make generate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 .PHONY: generate
-generate: generate-setup generate-deepcopy generate-typed-clients generate-typed-listers generate-typed-informers generate-cleanup
+generate: generate-deepcopy generate-typed-clients generate-typed-listers generate-typed-informers
 
 .PHONY: generate-setup
 generate-setup:


### PR DESCRIPTION
In https://github.com/kubernetes-sigs/network-policy-api/pull/80 we did a hack to ensure code was generated even if it wasn't placed at $GOPATH sigs.k8s.io/network-policy-api.

But that's not totally necessary always, like in my case where it was in that place, with this new change it started wiping off my entire sigs.k8s.io folder locally when I run make generate.

Instead let's make generate-setup and generate-cleanup optional as separate make commands and not club them with make generate. These kind of kinks depend on how each user's local setup is.