### PR TITLE
Fix comments for ingress/egress priority

### DIFF
--- a/apis/v1alpha1/adminnetworkpolicy_types.go
+++ b/apis/v1alpha1/adminnetworkpolicy_types.go
@@ -57,11 +57,6 @@ type AdminNetworkPolicySpec struct {
 	// higher precedence, and are checked before rules with higher priority values.
 	// All AdminNetworkPolicy rules have higher precedence than NetworkPolicy or
 	// BaselineAdminNetworkPolicy rules
-	// The relative precedence of the rules within a single ANP object (all of
-	// which share the priority) will be determined by the order in which the rule
-	// is written. Thus, a rule that appears at the top of the ingress/egress rules
-	// would take the highest precedence. If ingress rules are defined before egress
-	// rules in the same ANP object then ingress would take precedence and vice versa.
 	// The behavior is undefined if two ANP objects have same priority.
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=1000
@@ -71,15 +66,23 @@ type AdminNetworkPolicySpec struct {
 	Subject AdminNetworkPolicySubject `json:"subject"`
 
 	// Ingress is the list of Ingress rules to be applied to the selected pods.
-	// A total of 100 rules will be allowed in each ANP instance. ANPs with no
-	// ingress rules do not affect ingress traffic.
+	// A total of 100 rules will be allowed in each ANP instance.
+	// The relative precedence of ingress rules within a single ANP object (all of
+	// which share the priority) will be determined by the order in which the rule
+	// is written. Thus, a rule that appears at the top of the ingress rules
+	// would take the highest precedence.
+	// ANPs with no ingress rules do not affect ingress traffic.
 	// +optional
 	// +kubebuilder:validation:MaxItems=100
 	Ingress []AdminNetworkPolicyIngressRule `json:"ingress,omitempty"`
 
 	// Egress is the list of Egress rules to be applied to the selected pods.
-	// A total of 100 rules will be allowed in each ANP instance. ANPs with no
-	// egress rules do not affect egress traffic.
+	// A total of 100 rules will be allowed in each ANP instance.
+	// The relative precedence of egress rules within a single ANP object (all of
+	// which share the priority) will be determined by the order in which the rule
+	// is written. Thus, a rule that appears at the top of the egress rules
+	// would take the highest precedence.
+	// ANPs with no egress rules do not affect egress traffic.
 	// +optional
 	// +kubebuilder:validation:MaxItems=100
 	Egress []AdminNetworkPolicyEgressRule `json:"egress,omitempty"`

--- a/apis/v1alpha1/baselineadminnetworkpolicy_types.go
+++ b/apis/v1alpha1/baselineadminnetworkpolicy_types.go
@@ -56,6 +56,10 @@ type BaselineAdminNetworkPolicySpec struct {
 	// Ingress is the list of Ingress rules to be applied to the selected pods
 	// if they are not matched by any AdminNetworkPolicy or NetworkPolicy rules.
 	// A total of 100 Ingress rules will be allowed in each BANP instance.
+	// The relative precedence of ingress rules within a single BANP object
+	// will be determined by the order in which the rule is written.
+	// Thus, a rule that appears at the top of the ingress rules
+	// would take the highest precedence.
 	// BANPs with no ingress rules do not affect ingress traffic.
 	// +optional
 	// +kubebuilder:validation:MaxItems=100
@@ -63,8 +67,12 @@ type BaselineAdminNetworkPolicySpec struct {
 
 	// Egress is the list of Egress rules to be applied to the selected pods if
 	// they are not matched by any AdminNetworkPolicy or NetworkPolicy rules.
-	// A total of 100 Egress rules will be allowed in each BANP instance. BANPs
-	// with no egress rules do not affect egress traffic.
+	// A total of 100 Egress rules will be allowed in each BANP instance.
+	// The relative precedence of egress rules within a single BANP object
+	// will be determined by the order in which the rule is written.
+	// Thus, a rule that appears at the top of the egress rules
+	// would take the highest precedence.
+	// BANPs with no egress rules do not affect egress traffic.
 	// +optional
 	// +kubebuilder:validation:MaxItems=100
 	Egress []BaselineAdminNetworkPolicyEgressRule `json:"egress,omitempty"`

--- a/config/crd/bases/policy.networking.k8s.io_adminnetworkpolicies.yaml
+++ b/config/crd/bases/policy.networking.k8s.io_adminnetworkpolicies.yaml
@@ -49,7 +49,11 @@ spec:
               egress:
                 description: Egress is the list of Egress rules to be applied to the
                   selected pods. A total of 100 rules will be allowed in each ANP
-                  instance. ANPs with no egress rules do not affect egress traffic.
+                  instance. The relative precedence of egress rules within a single
+                  ANP object (all of which share the priority) will be determined
+                  by the order in which the rule is written. Thus, a rule that appears
+                  at the top of the egress rules would take the highest precedence.
+                  ANPs with no egress rules do not affect egress traffic.
                 items:
                   description: AdminNetworkPolicyEgressRule describes an action to
                     take on a particular set of traffic originating from pods selected
@@ -403,7 +407,11 @@ spec:
               ingress:
                 description: Ingress is the list of Ingress rules to be applied to
                   the selected pods. A total of 100 rules will be allowed in each
-                  ANP instance. ANPs with no ingress rules do not affect ingress traffic.
+                  ANP instance. The relative precedence of ingress rules within a
+                  single ANP object (all of which share the priority) will be determined
+                  by the order in which the rule is written. Thus, a rule that appears
+                  at the top of the ingress rules would take the highest precedence.
+                  ANPs with no ingress rules do not affect ingress traffic.
                 items:
                   description: AdminNetworkPolicyIngressRule describes an action to
                     take on a particular set of traffic destined for pods selected
@@ -758,13 +766,7 @@ spec:
                   priority values have higher precedence, and are checked before rules
                   with higher priority values. All AdminNetworkPolicy rules have higher
                   precedence than NetworkPolicy or BaselineAdminNetworkPolicy rules
-                  The relative precedence of the rules within a single ANP object
-                  (all of which share the priority) will be determined by the order
-                  in which the rule is written. Thus, a rule that appears at the top
-                  of the ingress/egress rules would take the highest precedence. If
-                  ingress rules are defined before egress rules in the same ANP object
-                  then ingress would take precedence and vice versa. The behavior
-                  is undefined if two ANP objects have same priority.
+                  The behavior is undefined if two ANP objects have same priority.
                 format: int32
                 maximum: 1000
                 minimum: 0

--- a/config/crd/bases/policy.networking.k8s.io_baselineadminnetworkpolicies.yaml
+++ b/config/crd/bases/policy.networking.k8s.io_baselineadminnetworkpolicies.yaml
@@ -47,8 +47,11 @@ spec:
                 description: Egress is the list of Egress rules to be applied to the
                   selected pods if they are not matched by any AdminNetworkPolicy
                   or NetworkPolicy rules. A total of 100 Egress rules will be allowed
-                  in each BANP instance. BANPs with no egress rules do not affect
-                  egress traffic.
+                  in each BANP instance. The relative precedence of egress rules within
+                  a single BANP object will be determined by the order in which the
+                  rule is written. Thus, a rule that appears at the top of the egress
+                  rules would take the highest precedence. BANPs with no egress rules
+                  do not affect egress traffic.
                 items:
                   description: BaselineAdminNetworkPolicyEgressRule describes an action
                     to take on a particular set of traffic originating from pods selected
@@ -397,8 +400,11 @@ spec:
                 description: Ingress is the list of Ingress rules to be applied to
                   the selected pods if they are not matched by any AdminNetworkPolicy
                   or NetworkPolicy rules. A total of 100 Ingress rules will be allowed
-                  in each BANP instance. BANPs with no ingress rules do not affect
-                  ingress traffic.
+                  in each BANP instance. The relative precedence of ingress rules
+                  within a single BANP object will be determined by the order in which
+                  the rule is written. Thus, a rule that appears at the top of the
+                  ingress rules would take the highest precedence. BANPs with no ingress
+                  rules do not affect ingress traffic.
                 items:
                   description: BaselineAdminNetworkPolicyIngressRule describes an
                     action to take on a particular set of traffic destined for pods


### PR DESCRIPTION
Clarify the relative order of precedence of rules for ingress/egress.