### PR TITLE
Add validation for allowing only 1 BANP in the cluster

### DIFF
--- a/apis/v1alpha1/baselineadminnetworkpolicy_types.go
+++ b/apis/v1alpha1/baselineadminnetworkpolicy_types.go
@@ -27,6 +27,7 @@ import (
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:metadata:annotations="api-approved.kubernetes.io=https://github.com/kubernetes/enhancements/pull/2522"
+// +kubebuilder:validation:XValidation:rule="self.metadata.name == 'default'",message="Only one baseline admin network policy with metadata.name=\"default\" can be created in the cluster"
 // BaselineAdminNetworkPolicy is a cluster level resource that is part of the
 // AdminNetworkPolicy API.
 type BaselineAdminNetworkPolicy struct {

--- a/config/crd/bases/policy.networking.k8s.io_baselineadminnetworkpolicies.yaml
+++ b/config/crd/bases/policy.networking.k8s.io_baselineadminnetworkpolicies.yaml
@@ -977,6 +977,10 @@ spec:
         - metadata
         - spec
         type: object
+        x-kubernetes-validations:
+        - message: Only one baseline admin network policy with metadata.name="default"
+            can be created in the cluster
+          rule: self.metadata.name == 'default'
     served: true
     storage: true
     subresources:


### PR DESCRIPTION
The KEP says that at a given time, we can have only 1 BANP in the cluster. No use cases for more than one was brough forth so far. So in the v1alpha1 of the API let's stick to this and we can later remove this
restriction if more than one BANP is required, but then that will entail confusions since BANP doesn't have a priority set.

Since there is no straight forward way to limit
Items in the BaselineAdminNetworkPolicyList, we will use the new xvalidation:
https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/2876-crd-validation-expression-language/README.md#proposal approach here. See how singleton is expressed.

Testing results:
```
$ oc create -f banp.yaml 
The BaselineAdminNetworkPolicy "default0" is invalid: <nil>: Invalid value: "object": Only one baseline admin network policy with metadata.name="default" can be created
```