### PR TITLE
remove unactive code owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,5 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - abhiraut
-  - rikatz
   - astoycos
   - Dyanngg


### PR DESCRIPTION
This commit removes some code owners who are no longer active in the sig-network-policy-api subgroup.

@abhiraut @rikatz PTAL just to make sure you are on board with this