### PR TITLE
Add ANP conformance tests for `.Spec.Ingress` and `.Spec.Egress` fields

### DIFF
--- a/conformance/tests/admin-network-policy-core-egress-sctp-rules.go
+++ b/conformance/tests/admin-network-policy-core-egress-sctp-rules.go
@@ -1,0 +1,219 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/network-policy-api/apis/v1alpha1"
+	"sigs.k8s.io/network-policy-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/network-policy-api/conformance/utils/suite"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests,
+		AdminNetworkPolicyEgressSCTP,
+	)
+}
+
+var AdminNetworkPolicyEgressSCTP = suite.ConformanceTest{
+	ShortName:   "AdminNetworkPolicyEgressSCTP",
+	Description: "Tests support for egress traffic (SCTP protocol) using admin network policy API based on a server and client model",
+	Features: []suite.SupportedFeature{
+		suite.SupportAdminNetworkPolicy,
+	},
+	Manifests: []string{"tests/admin-network-policy-core-egress-sctp-rules_base.yaml"},
+	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+
+		t.Run("Should support an 'allow-egress' policy for SCTP protocol; ensure rule ordering is respected", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `egress-sctp` ANP
+			// harry-potter-0 is our server pod in gryffindor namespace
+			clientPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-gryffindor",
+				Name:      "harry-potter-0",
+			}, clientPod)
+			framework.ExpectNoError(err, "unable to fetch the server pod")
+			// luna-lovegood-0 is our client pod in ravenclaw namespace
+			// ensure egress is ALLOWED to gryffindor from ravenclaw
+			// egressRule at index0 will take precedence over egressRule at index1; thus ALLOW takes precedence over DENY since rules are ordered
+			success := kubernetes.PokeServer(t, "network-policy-conformance-ravenclaw", "luna-lovegood-0", "sctp",
+				clientPod.Status.PodIP, int32(9003), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+			// luna-lovegood-1 is our client pod in ravenclaw namespace
+			success = kubernetes.PokeServer(t, "network-policy-conformance-ravenclaw", "luna-lovegood-1", "sctp",
+				clientPod.Status.PodIP, int32(9005), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+		})
+
+		t.Run("Should support an 'allow-egress' policy for SCTP protocol at the specified port", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `egress-sctp` ANP
+			// cedric-diggory-1 is our server pod in hufflepuff namespace
+			clientPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-hufflepuff",
+				Name:      "cedric-diggory-1",
+			}, clientPod)
+			framework.ExpectNoError(err, "unable to fetch the server pod")
+			// luna-lovegood-0 is our client pod in ravenclaw namespace
+			// ensure egress is ALLOWED to hufflepuff from ravenclaw at port 9003; egressRule at index5
+			success := kubernetes.PokeServer(t, "network-policy-conformance-ravenclaw", "luna-lovegood-0", "sctp",
+				clientPod.Status.PodIP, int32(9003), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+			// luna-lovegood-1 is our client pod in ravenclaw namespace
+			// ensure egress is DENIED to hufflepuff from ravenclaw for rest of the traffic; egressRule at index6
+			success = kubernetes.PokeServer(t, "network-policy-conformance-ravenclaw", "luna-lovegood-1", "sctp",
+				clientPod.Status.PodIP, int32(9005), s.TimeoutConfig.RequestTimeout, false)
+			assert.Equal(t, true, success)
+		})
+
+		t.Run("Should support an 'deny-egress' policy for SCTP protocol; ensure rule ordering is respected", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `egress-sctp` ANP
+			// harry-potter-0 is our server pod in gryffindor namespace
+			clientPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-gryffindor",
+				Name:      "harry-potter-1",
+			}, clientPod)
+			framework.ExpectNoError(err, "unable to fetch the server pod")
+			anp := &v1alpha1.AdminNetworkPolicy{}
+			err = s.Client.Get(ctx, client.ObjectKey{
+				Name: "egress-sctp",
+			}, anp)
+			framework.ExpectNoError(err, "unable to fetch the admin network policy")
+			// swap rules at index0 and index1
+			allowRule := anp.DeepCopy().Spec.Egress[0]
+			anp.Spec.Egress[0] = anp.DeepCopy().Spec.Egress[1]
+			anp.Spec.Egress[1] = allowRule
+			err = s.Client.Update(ctx, anp)
+			framework.ExpectNoError(err, "unable to update the admin network policy")
+			// luna-lovegood-0 is our client pod in gryffindor namespace
+			// ensure egress is DENIED to gryffindor from ravenclaw
+			// egressRule at index0 will take precedence over egressRule at index1; thus DENY takes precedence over ALLOW since rules are ordered
+			success := kubernetes.PokeServer(t, "network-policy-conformance-ravenclaw", "luna-lovegood-0", "sctp",
+				clientPod.Status.PodIP, int32(9003), s.TimeoutConfig.RequestTimeout, false)
+			assert.Equal(t, true, success)
+			// luna-lovegood-1 is our client pod in ravenclaw namespace
+			success = kubernetes.PokeServer(t, "network-policy-conformance-ravenclaw", "luna-lovegood-1", "sctp",
+				clientPod.Status.PodIP, int32(9005), s.TimeoutConfig.RequestTimeout, false)
+			assert.Equal(t, true, success)
+		})
+
+		t.Run("Should support a 'deny-egress' policy for SCTP protocol at the specified port", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `egress-sctp` ANP
+			// draco-malfoy-0 is our server pod in slytherin namespace
+			clientPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-slytherin",
+				Name:      "draco-malfoy-0",
+			}, clientPod)
+			framework.ExpectNoError(err, "unable to fetch the server pod")
+			// luna-lovegood-0 is our client pod in ravenclaw namespace
+			// ensure egress to slytherin is DENIED from ravenclaw at port 9003; egressRule at index3
+			success := kubernetes.PokeServer(t, "network-policy-conformance-ravenclaw", "luna-lovegood-0", "sctp",
+				clientPod.Status.PodIP, int32(9003), s.TimeoutConfig.RequestTimeout, false)
+			assert.Equal(t, true, success)
+			// luna-lovegood-1 is our client pod in ravenclaw namespace
+			// ensure egress to slytherin is ALLOWED from ravenclaw for rest of the traffic; matches no rules hence allowed
+			success = kubernetes.PokeServer(t, "network-policy-conformance-ravenclaw", "luna-lovegood-1", "sctp",
+				clientPod.Status.PodIP, int32(9005), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+		})
+
+		t.Run("Should support an 'pass-egress' policy for SCTP protocol; ensure rule ordering is respected", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `egress-sctp` ANP
+			// harry-potter-0 is our server pod in gryffindor namespace
+			clientPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-gryffindor",
+				Name:      "harry-potter-1",
+			}, clientPod)
+			framework.ExpectNoError(err, "unable to fetch the server pod")
+			anp := &v1alpha1.AdminNetworkPolicy{}
+			err = s.Client.Get(ctx, client.ObjectKey{
+				Name: "egress-sctp",
+			}, anp)
+			framework.ExpectNoError(err, "unable to fetch the admin network policy")
+			// swap rules at index0 and index2
+			denyRule := anp.DeepCopy().Spec.Egress[0]
+			anp.Spec.Egress[0] = anp.DeepCopy().Spec.Egress[2]
+			anp.Spec.Egress[2] = denyRule
+			err = s.Client.Update(ctx, anp)
+			framework.ExpectNoError(err, "unable to update the admin network policy")
+			// luna-lovegood-0 is our client pod in ravenclaw namespace
+			// ensure egress is PASSED from gryffindor to ravenclaw
+			// egressRule at index0 will take precedence over egressRule at index1&index2; thus PASS takes precedence over ALLOW/DENY since rules are ordered
+			success := kubernetes.PokeServer(t, "network-policy-conformance-ravenclaw", "luna-lovegood-0", "sctp",
+				clientPod.Status.PodIP, int32(9003), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+			// luna-lovegood-1 is our client pod in ravenclaw namespace
+			success = kubernetes.PokeServer(t, "network-policy-conformance-ravenclaw", "luna-lovegood-1", "sctp",
+				clientPod.Status.PodIP, int32(9005), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+		})
+
+		t.Run("Should support a 'pass-egress' policy for SCTP protocol at the specified port", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `egress-sctp` ANP
+			// draco-malfoy-0 is our server pod in slytherin namespace
+			clientPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-slytherin",
+				Name:      "draco-malfoy-0",
+			}, clientPod)
+			framework.ExpectNoError(err, "unable to fetch the server pod")
+			anp := &v1alpha1.AdminNetworkPolicy{}
+			err = s.Client.Get(ctx, client.ObjectKey{
+				Name: "egress-sctp",
+			}, anp)
+			framework.ExpectNoError(err, "unable to fetch the admin network policy")
+			// swap rules at index3 and index4
+			denyRule := anp.DeepCopy().Spec.Egress[3]
+			anp.Spec.Egress[3] = anp.DeepCopy().Spec.Egress[4]
+			anp.Spec.Egress[4] = denyRule
+			err = s.Client.Update(ctx, anp)
+			framework.ExpectNoError(err, "unable to update the admin network policy")
+			// luna-lovegood-0 is our client pod in ravenclaw namespace
+			// ensure egress to slytherin is PASSED from ravenclaw at port 9003; egressRule at index3
+			success := kubernetes.PokeServer(t, "network-policy-conformance-ravenclaw", "luna-lovegood-0", "sctp",
+				clientPod.Status.PodIP, int32(9003), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+			// luna-lovegood-1 is our client pod in ravenclaw namespace
+			// ensure egress to slytherin is ALLOWED from ravenclaw for rest of the traffic; matches no rules hence allowed
+			success = kubernetes.PokeServer(t, "network-policy-conformance-ravenclaw", "luna-lovegood-1", "sctp",
+				clientPod.Status.PodIP, int32(9005), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+		})
+	},
+}

--- a/conformance/tests/admin-network-policy-core-egress-sctp-rules_base.yaml
+++ b/conformance/tests/admin-network-policy-core-egress-sctp-rules_base.yaml
@@ -1,0 +1,72 @@
+apiVersion: policy.networking.k8s.io/v1alpha1
+kind: AdminNetworkPolicy
+metadata:
+  name: egress-sctp
+spec:
+  priority: 8
+  subject:
+    namespaces:
+      matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+  egress:
+  - name: "allow-to-gryffindor-everything"
+    action: "Allow"
+    to:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: network-policy-conformance-gryffindor
+  - name: "deny-to-gryffindor-everything"
+    action: "Deny"
+    to:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: network-policy-conformance-gryffindor
+  - name: "pass-to-gryffindor-everything"
+    action: "Pass"
+    to:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: network-policy-conformance-gryffindor
+  - name: "deny-to-slytherin-at-port-9003"
+    action: "Deny"
+    to:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: network-policy-conformance-slytherin
+    ports:
+      - portNumber:
+          protocol: SCTP
+          port: 9003
+  - name: "pass-to-slytherin-at-port-9003"
+    action: "Pass"
+    to:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: network-policy-conformance-slytherin
+    ports:
+      - portNumber:
+          protocol: SCTP
+          port: 9003
+  - name: "allow-to-hufflepuff-at-port-9003"
+    action: "Allow"
+    to:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
+    ports:
+      - portNumber:
+          protocol: SCTP
+          port: 9003
+  - name: "deny-to-hufflepuff-everything-else"
+    action: "Deny"
+    to:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: network-policy-conformance-hufflepuff

--- a/conformance/tests/admin-network-policy-core-egress-tcp-rules.go
+++ b/conformance/tests/admin-network-policy-core-egress-tcp-rules.go
@@ -1,0 +1,218 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/network-policy-api/apis/v1alpha1"
+	"sigs.k8s.io/network-policy-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/network-policy-api/conformance/utils/suite"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests,
+		AdminNetworkPolicyEgressTCP,
+	)
+}
+
+var AdminNetworkPolicyEgressTCP = suite.ConformanceTest{
+	ShortName:   "AdminNetworkPolicyEgressTCP",
+	Description: "Tests support for egress traffic (TCP protocol) using admin network policy API based on a server and client model",
+	Features: []suite.SupportedFeature{
+		suite.SupportAdminNetworkPolicy,
+	},
+	Manifests: []string{"tests/admin-network-policy-core-egress-tcp-rules_base.yaml"},
+	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+
+		t.Run("Should support an 'allow-egress' policy for TCP protocol; ensure rule ordering is respected", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `egress-tcp` ANP
+			// luna-lovegood-0 is our server pod in ravenclaw namespace
+			clientPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-ravenclaw",
+				Name:      "luna-lovegood-0",
+			}, clientPod)
+			framework.ExpectNoError(err, "unable to fetch the server pod")
+			// harry-potter-0 is our client pod in gryffindor namespace
+			// ensure egress is ALLOWED to ravenclaw from gryffindor
+			// egressRule at index0 will take precedence over egressRule at index1; thus ALLOW takes precedence over DENY since rules are ordered
+			success := kubernetes.PokeServer(t, "network-policy-conformance-gryffindor", "harry-potter-0", "tcp",
+				clientPod.Status.PodIP, int32(80), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+			success = kubernetes.PokeServer(t, "network-policy-conformance-gryffindor", "harry-potter-1", "tcp",
+				clientPod.Status.PodIP, int32(8080), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+		})
+
+		t.Run("Should support an 'allow-egress' policy for TCP protocol at the specified port", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `egress-tcp` ANP
+			// cedric-diggory-1 is our server pod in hufflepuff namespace
+			clientPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-hufflepuff",
+				Name:      "cedric-diggory-1",
+			}, clientPod)
+			framework.ExpectNoError(err, "unable to fetch the server pod")
+			// harry-potter-0 is our client pod in gryffindor namespace
+			// ensure egress is ALLOWED to hufflepuff from gryffindor at port 80; egressRule at index5
+			success := kubernetes.PokeServer(t, "network-policy-conformance-gryffindor", "harry-potter-0", "tcp",
+				clientPod.Status.PodIP, int32(8080), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+			// harry-potter-1 is our client pod in gryffindor namespace
+			// ensure egress is DENIED to hufflepuff from gryffindor for rest of the traffic; egressRule at index6
+			success = kubernetes.PokeServer(t, "network-policy-conformance-gryffindor", "harry-potter-1", "tcp",
+				clientPod.Status.PodIP, int32(80), s.TimeoutConfig.RequestTimeout, false)
+			assert.Equal(t, true, success)
+		})
+
+		t.Run("Should support an 'deny-egress' policy for TCP protocol; ensure rule ordering is respected", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `egress-tcp` ANP
+			// luna-lovegood-1 is our server pod in ravenclaw namespace
+			clientPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-ravenclaw",
+				Name:      "luna-lovegood-1",
+			}, clientPod)
+			framework.ExpectNoError(err, "unable to fetch the server pod")
+			anp := &v1alpha1.AdminNetworkPolicy{}
+			err = s.Client.Get(ctx, client.ObjectKey{
+				Name: "egress-tcp",
+			}, anp)
+			framework.ExpectNoError(err, "unable to fetch the admin network policy")
+			// swap rules at index0 and index1
+			allowRule := anp.DeepCopy().Spec.Egress[0]
+			anp.Spec.Egress[0] = anp.DeepCopy().Spec.Egress[1]
+			anp.Spec.Egress[1] = allowRule
+			err = s.Client.Update(ctx, anp)
+			framework.ExpectNoError(err, "unable to update the admin network policy")
+			// harry-potter-0 is our client pod in gryffindor namespace
+			// ensure egress is DENIED to ravenclaw from gryffindor
+			// egressRule at index0 will take precedence over egressRule at index1; thus DENY takes precedence over ALLOW since rules are ordered
+			success := kubernetes.PokeServer(t, "network-policy-conformance-gryffindor", "harry-potter-0", "tcp",
+				clientPod.Status.PodIP, int32(80), s.TimeoutConfig.RequestTimeout, false)
+			assert.Equal(t, true, success)
+			// harry-potter-1 is our client pod in gryffindor namespace
+			success = kubernetes.PokeServer(t, "network-policy-conformance-gryffindor", "harry-potter-1", "tcp",
+				clientPod.Status.PodIP, int32(8080), s.TimeoutConfig.RequestTimeout, false)
+			assert.Equal(t, true, success)
+		})
+
+		t.Run("Should support a 'deny-egress' policy for TCP protocol at the specified port", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `egress-tcp` ANP
+			// draco-malfoy-0 is our server pod in slytherin namespace
+			clientPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-slytherin",
+				Name:      "draco-malfoy-0",
+			}, clientPod)
+			framework.ExpectNoError(err, "unable to fetch the server pod")
+			// harry-potter-0 is our client pod in gryffindor namespace
+			// ensure egress to slytherin is DENIED from gryffindor at port 80; egressRule at index3
+			success := kubernetes.PokeServer(t, "network-policy-conformance-gryffindor", "harry-potter-0", "tcp",
+				clientPod.Status.PodIP, int32(80), s.TimeoutConfig.RequestTimeout, false)
+			assert.Equal(t, true, success)
+			// harry-potter-1 is our client pod in gryffindor namespace
+			// ensure egress to slytherin is ALLOWED from gryffindor for rest of the traffic; matches no rules hence allowed
+			success = kubernetes.PokeServer(t, "network-policy-conformance-gryffindor", "harry-potter-1", "tcp",
+				clientPod.Status.PodIP, int32(8080), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+		})
+
+		t.Run("Should support an 'pass-egress' policy for TCP protocol; ensure rule ordering is respected", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `egress-tcp` ANP
+			// luna-lovegood-0 is our server pod in ravenclaw namespace
+			clientPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-ravenclaw",
+				Name:      "luna-lovegood-0",
+			}, clientPod)
+			framework.ExpectNoError(err, "unable to fetch the server pod")
+			anp := &v1alpha1.AdminNetworkPolicy{}
+			err = s.Client.Get(ctx, client.ObjectKey{
+				Name: "egress-tcp",
+			}, anp)
+			framework.ExpectNoError(err, "unable to fetch the admin network policy")
+			// swap rules at index0 and index2
+			denyRule := anp.DeepCopy().Spec.Egress[0]
+			anp.Spec.Egress[0] = anp.DeepCopy().Spec.Egress[2]
+			anp.Spec.Egress[2] = denyRule
+			err = s.Client.Update(ctx, anp)
+			framework.ExpectNoError(err, "unable to update the admin network policy")
+			// harry-potter-0 is our server pod in gryffindor namespace
+			// ensure egress is PASSED from gryffindor to ravenclaw
+			// egressRule at index0 will take precedence over egressRule at index1&index2; thus PASS takes precedence over ALLOW/DENY since rules are ordered
+			success := kubernetes.PokeServer(t, "network-policy-conformance-gryffindor", "harry-potter-0", "tcp",
+				clientPod.Status.PodIP, int32(80), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+			// harry-potter-1 is our server pod in gryffindor namespace
+			success = kubernetes.PokeServer(t, "network-policy-conformance-gryffindor", "harry-potter-1", "tcp",
+				clientPod.Status.PodIP, int32(8080), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+		})
+
+		t.Run("Should support a 'pass-egress' policy for TCP protocol at the specified port", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `egress-tcp` ANP
+			// draco-malfoy-0 is our server pod in slytherin namespace
+			clientPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-slytherin",
+				Name:      "draco-malfoy-0",
+			}, clientPod)
+			framework.ExpectNoError(err, "unable to fetch the server pod")
+			anp := &v1alpha1.AdminNetworkPolicy{}
+			err = s.Client.Get(ctx, client.ObjectKey{
+				Name: "egress-tcp",
+			}, anp)
+			framework.ExpectNoError(err, "unable to fetch the admin network policy")
+			// swap rules at index3 and index4
+			denyRule := anp.DeepCopy().Spec.Egress[3]
+			anp.Spec.Egress[3] = anp.DeepCopy().Spec.Egress[4]
+			anp.Spec.Egress[4] = denyRule
+			err = s.Client.Update(ctx, anp)
+			framework.ExpectNoError(err, "unable to update the admin network policy")
+			// harry-potter-0 is our client pod in gryffindor namespace
+			// ensure egress from gryffindor is PASSED to slytherin at port 80; egressRule at index3
+			success := kubernetes.PokeServer(t, "network-policy-conformance-gryffindor", "harry-potter-0", "tcp",
+				clientPod.Status.PodIP, int32(80), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+			// harry-potter-1 is our client pod in gryffindor namespace
+			// ensure egress from gryffindor is ALLOWED to slytherin for rest of the traffic; matches no rules hence allowed
+			success = kubernetes.PokeServer(t, "network-policy-conformance-gryffindor", "harry-potter-1", "tcp",
+				clientPod.Status.PodIP, int32(8080), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+		})
+	},
+}

--- a/conformance/tests/admin-network-policy-core-egress-tcp-rules_base.yaml
+++ b/conformance/tests/admin-network-policy-core-egress-tcp-rules_base.yaml
@@ -1,0 +1,72 @@
+apiVersion: policy.networking.k8s.io/v1alpha1
+kind: AdminNetworkPolicy
+metadata:
+  name: egress-tcp
+spec:
+  priority: 6
+  subject:
+    namespaces:
+      matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-gryffindor
+  egress:
+  - name: "allow-to-ravenclaw-everything"
+    action: "Allow"
+    to:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+  - name: "deny-to-ravenclaw-everything"
+    action: "Deny"
+    to:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+  - name: "pass-to-ravenclaw-everything"
+    action: "Pass"
+    to:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+  - name: "deny-to-slytherin-at-port-80"
+    action: "Deny"
+    to:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: network-policy-conformance-slytherin
+    ports:
+      - portNumber:
+          protocol: TCP
+          port: 80
+  - name: "pass-to-slytherin-at-port-80"
+    action: "Pass"
+    to:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: network-policy-conformance-slytherin
+    ports:
+      - portNumber:
+          protocol: TCP
+          port: 80
+  - name: "allow-to-hufflepuff-at-port-8080"
+    action: "Allow"
+    to:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
+    ports:
+      - portNumber:
+          protocol: TCP
+          port: 8080
+  - name: "deny-to-hufflepuff-everything-else"
+    action: "Deny"
+    to:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: network-policy-conformance-hufflepuff

--- a/conformance/tests/admin-network-policy-core-egress-udp-rules.go
+++ b/conformance/tests/admin-network-policy-core-egress-udp-rules.go
@@ -1,0 +1,219 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/network-policy-api/apis/v1alpha1"
+	"sigs.k8s.io/network-policy-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/network-policy-api/conformance/utils/suite"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests,
+		AdminNetworkPolicyEgressUDP,
+	)
+}
+
+var AdminNetworkPolicyEgressUDP = suite.ConformanceTest{
+	ShortName:   "AdminNetworkPolicyEgressUDP",
+	Description: "Tests support for egress traffic (UDP protocol) using admin network policy API based on a server and client model",
+	Features: []suite.SupportedFeature{
+		suite.SupportAdminNetworkPolicy,
+	},
+	Manifests: []string{"tests/admin-network-policy-core-egress-udp-rules_base.yaml"},
+	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+
+		t.Run("Should support an 'allow-egress' policy for UDP protocol; ensure rule ordering is respected", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `egress-udp` ANP
+			// luna-lovegood-0 is our server pod in ravenclaw namespace
+			clientPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-ravenclaw",
+				Name:      "luna-lovegood-0",
+			}, clientPod)
+			framework.ExpectNoError(err, "unable to fetch the server pod")
+			// cedric-diggory-0 is our client pod in hufflepuff namespace
+			// ensure egress is ALLOWED to ravenclaw from hufflepuff
+			// egressRule at index0 will take precedence over egressRule at index1; thus ALLOW takes precedence over DENY since rules are ordered
+			success := kubernetes.PokeServer(t, "network-policy-conformance-hufflepuff", "cedric-diggory-0", "udp",
+				clientPod.Status.PodIP, int32(53), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+			// cedric-diggory-1 is our client pod in hufflepuff namespace
+			success = kubernetes.PokeServer(t, "network-policy-conformance-hufflepuff", "cedric-diggory-1", "udp",
+				clientPod.Status.PodIP, int32(5353), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+		})
+
+		t.Run("Should support an 'allow-egress' policy for UDP protocol at the specified port", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `egress-udp` ANP
+			// harry-potter-1 is our server pod in gryffindor namespace
+			clientPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-gryffindor",
+				Name:      "harry-potter-1",
+			}, clientPod)
+			framework.ExpectNoError(err, "unable to fetch the server pod")
+			// cedric-diggory-0 is our client pod in hufflepuff namespace
+			// ensure egress is ALLOWED to gryffindor from hufflepuff at port 53; egressRule at index5
+			success := kubernetes.PokeServer(t, "network-policy-conformance-hufflepuff", "cedric-diggory-0", "udp",
+				clientPod.Status.PodIP, int32(53), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+			// cedric-diggory-1 is our client pod in hufflepuff namespace
+			// ensure egress is DENIED to gryffindor from hufflepuff for rest of the traffic; egressRule at index6
+			success = kubernetes.PokeServer(t, "network-policy-conformance-hufflepuff", "cedric-diggory-1", "udp",
+				clientPod.Status.PodIP, int32(5353), s.TimeoutConfig.RequestTimeout, false)
+			assert.Equal(t, true, success)
+		})
+
+		t.Run("Should support an 'deny-egress' policy for UDP protocol; ensure rule ordering is respected", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `egress-udp` ANP
+			// luna-lovegood-1 is our server pod in ravenclaw namespace
+			clientPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-ravenclaw",
+				Name:      "luna-lovegood-1",
+			}, clientPod)
+			framework.ExpectNoError(err, "unable to fetch the server pod")
+			anp := &v1alpha1.AdminNetworkPolicy{}
+			err = s.Client.Get(ctx, client.ObjectKey{
+				Name: "egress-udp",
+			}, anp)
+			framework.ExpectNoError(err, "unable to fetch the admin network policy")
+			// swap rules at index0 and index1
+			allowRule := anp.DeepCopy().Spec.Egress[0]
+			anp.Spec.Egress[0] = anp.DeepCopy().Spec.Egress[1]
+			anp.Spec.Egress[1] = allowRule
+			err = s.Client.Update(ctx, anp)
+			framework.ExpectNoError(err, "unable to update the admin network policy")
+			// cedric-diggory-0 is our client pod in hufflepuff namespace
+			// ensure egress is DENIED to ravenclaw to hufflepuff
+			// egressRule at index0 will take precedence over egressRule at index1; thus DENY takes precedence over ALLOW since rules are ordered
+			success := kubernetes.PokeServer(t, "network-policy-conformance-hufflepuff", "cedric-diggory-0", "udp",
+				clientPod.Status.PodIP, int32(53), s.TimeoutConfig.RequestTimeout, false)
+			assert.Equal(t, true, success)
+			// cedric-diggory-1 is our client pod in hufflepuff namespace
+			success = kubernetes.PokeServer(t, "network-policy-conformance-hufflepuff", "cedric-diggory-1", "udp",
+				clientPod.Status.PodIP, int32(5353), s.TimeoutConfig.RequestTimeout, false)
+			assert.Equal(t, true, success)
+		})
+
+		t.Run("Should support a 'deny-egress' policy for UDP protocol at the specified port", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `egress-udp` ANP
+			// draco-malfoy-0 is our server pod in slytherin namespace
+			clientPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-slytherin",
+				Name:      "draco-malfoy-0",
+			}, clientPod)
+			framework.ExpectNoError(err, "unable to fetch the server pod")
+			// cedric-diggory-0 is our client pod in hufflepuff namespace
+			// ensure egress to slytherin is DENIED from hufflepuff at port 80; egressRule at index3
+			success := kubernetes.PokeServer(t, "network-policy-conformance-hufflepuff", "cedric-diggory-0", "udp",
+				clientPod.Status.PodIP, int32(5353), s.TimeoutConfig.RequestTimeout, false)
+			assert.Equal(t, true, success)
+			// cedric-diggory-0 is our client pod in hufflepuff namespace
+			// ensure egress to slytherin is ALLOWED from hufflepuff for rest of the traffic; matches no rules hence allowed
+			success = kubernetes.PokeServer(t, "network-policy-conformance-hufflepuff", "cedric-diggory-1", "udp",
+				clientPod.Status.PodIP, int32(53), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+		})
+
+		t.Run("Should support an 'pass-egress' policy for UDP protocol; ensure rule ordering is respected", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `egress-udp` ANP
+			// luna-lovegood-1 is our server pod in ravenclaw namespace
+			clientPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-ravenclaw",
+				Name:      "luna-lovegood-1",
+			}, clientPod)
+			framework.ExpectNoError(err, "unable to fetch the server pod")
+			anp := &v1alpha1.AdminNetworkPolicy{}
+			err = s.Client.Get(ctx, client.ObjectKey{
+				Name: "egress-udp",
+			}, anp)
+			framework.ExpectNoError(err, "unable to fetch the admin network policy")
+			// swap rules at index0 and index2
+			denyRule := anp.DeepCopy().Spec.Egress[0]
+			anp.Spec.Egress[0] = anp.DeepCopy().Spec.Egress[2]
+			anp.Spec.Egress[2] = denyRule
+			err = s.Client.Update(ctx, anp)
+			framework.ExpectNoError(err, "unable to update the admin network policy")
+			// cedric-diggory-0 is our client pod in hufflepuff namespace
+			// ensure egress is PASSED to ravenclaw from hufflepuff
+			// egressRule at index0 will take precedence over egressRule at index1&index2; thus PASS takes precedence over ALLOW/DENY since rules are ordered
+			success := kubernetes.PokeServer(t, "network-policy-conformance-hufflepuff", "cedric-diggory-0", "udp",
+				clientPod.Status.PodIP, int32(5353), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+			// cedric-diggory-1 is our client pod in hufflepuff namespace
+			success = kubernetes.PokeServer(t, "network-policy-conformance-hufflepuff", "cedric-diggory-1", "udp",
+				clientPod.Status.PodIP, int32(53), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+		})
+
+		t.Run("Should support a 'pass-egress' policy for UDP protocol at the specified port", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `egress-udp` ANP
+			// draco-malfoy-0 is our server pod in slytherin namespace
+			clientPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-slytherin",
+				Name:      "draco-malfoy-0",
+			}, clientPod)
+			framework.ExpectNoError(err, "unable to fetch the server pod")
+			anp := &v1alpha1.AdminNetworkPolicy{}
+			err = s.Client.Get(ctx, client.ObjectKey{
+				Name: "egress-udp",
+			}, anp)
+			framework.ExpectNoError(err, "unable to fetch the admin network policy")
+			// swap rules at index3 and index4
+			denyRule := anp.DeepCopy().Spec.Egress[3]
+			anp.Spec.Egress[3] = anp.DeepCopy().Spec.Egress[4]
+			anp.Spec.Egress[4] = denyRule
+			err = s.Client.Update(ctx, anp)
+			framework.ExpectNoError(err, "unable to update the admin network policy")
+			// cedric-diggory-0 is our client pod in hufflepuff namespace
+			// ensure egress to slytherin is PASSED from hufflepuff at port 5353; egressRule at index3
+			success := kubernetes.PokeServer(t, "network-policy-conformance-hufflepuff", "cedric-diggory-0", "udp",
+				clientPod.Status.PodIP, int32(5353), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+			// cedric-diggory-1 is our client pod in hufflepuff namespace
+			// ensure egress to slytherin is ALLOWED from hufflepuff for rest of the traffic; matches no rules hence allowed
+			success = kubernetes.PokeServer(t, "network-policy-conformance-hufflepuff", "cedric-diggory-1", "udp",
+				clientPod.Status.PodIP, int32(53), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+		})
+	},
+}

--- a/conformance/tests/admin-network-policy-core-egress-udp-rules_base.yaml
+++ b/conformance/tests/admin-network-policy-core-egress-udp-rules_base.yaml
@@ -1,0 +1,72 @@
+apiVersion: policy.networking.k8s.io/v1alpha1
+kind: AdminNetworkPolicy
+metadata:
+  name: egress-udp
+spec:
+  priority: 7
+  subject:
+    namespaces:
+      matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
+  egress:
+  - name: "allow-to-ravenclaw-everything"
+    action: "Allow"
+    to:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+  - name: "deny-to-ravenclaw-everything"
+    action: "Deny"
+    to:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+  - name: "pass-to-ravenclaw-everything"
+    action: "Pass"
+    to:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+  - name: "deny-to-slytherin-at-port-5353"
+    action: "Deny"
+    to:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: network-policy-conformance-slytherin
+    ports:
+      - portNumber:
+          protocol: UDP
+          port: 5353
+  - name: "pass-to-slytherin-at-port-5353"
+    action: "Pass"
+    to:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: network-policy-conformance-slytherin
+    ports:
+      - portNumber:
+          protocol: UDP
+          port: 5353
+  - name: "allow-to-gryffindor-at-port-53"
+    action: "Allow"
+    to:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: network-policy-conformance-gryffindor
+    ports:
+      - portNumber:
+          protocol: UDP
+          port: 53
+  - name: "deny-to-gryffindor-everything-else"
+    action: "Deny"
+    to:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: network-policy-conformance-gryffindor

--- a/conformance/tests/admin-network-policy-core-ingress-sctp-rules.go
+++ b/conformance/tests/admin-network-policy-core-ingress-sctp-rules.go
@@ -1,0 +1,218 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/network-policy-api/apis/v1alpha1"
+	"sigs.k8s.io/network-policy-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/network-policy-api/conformance/utils/suite"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests,
+		AdminNetworkPolicyIngressSCTP,
+	)
+}
+
+var AdminNetworkPolicyIngressSCTP = suite.ConformanceTest{
+	ShortName:   "AdminNetworkPolicyIngressSCTP",
+	Description: "Tests support for ingress traffic (SCTP protocol) using admin network policy API based on a server and client model",
+	Features: []suite.SupportedFeature{
+		suite.SupportAdminNetworkPolicy,
+	},
+	Manifests: []string{"tests/admin-network-policy-core-ingress-sctp-rules_base.yaml"},
+	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+
+		t.Run("Should support an 'allow-ingress' policy for SCTP protocol; ensure rule ordering is respected", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `ingress-sctp` ANP
+			// luna-lovegood-0 is our server pod in ravenclaw namespace
+			clientPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-ravenclaw",
+				Name:      "luna-lovegood-0",
+			}, clientPod)
+			framework.ExpectNoError(err, "unable to fetch the server pod")
+			// harry-potter-0 is our client pod in gryffindor namespace
+			// ensure ingress is ALLOWED from gryffindor to ravenclaw
+			// ingressRule at index0 will take precedence over ingressRule at index1; thus ALLOW takes precedence over DENY since rules are ordered
+			success := kubernetes.PokeServer(t, "network-policy-conformance-gryffindor", "harry-potter-0", "sctp",
+				clientPod.Status.PodIP, int32(9003), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+			success = kubernetes.PokeServer(t, "network-policy-conformance-gryffindor", "harry-potter-1", "sctp",
+				clientPod.Status.PodIP, int32(9005), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+		})
+
+		t.Run("Should support an 'allow-ingress' policy for SCTP protocol at the specified port", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `ingress-sctp` ANP
+			// luna-lovegood-1 is our server pod in ravenclaw namespace
+			clientPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-ravenclaw",
+				Name:      "luna-lovegood-1",
+			}, clientPod)
+			framework.ExpectNoError(err, "unable to fetch the server pod")
+			// cedric-diggory-0 is our client pod in hufflepuff namespace
+			// ensure ingress is ALLOWED from hufflepuff to ravenclaw at port 9003; ingressRule at index5
+			success := kubernetes.PokeServer(t, "network-policy-conformance-hufflepuff", "cedric-diggory-0", "sctp",
+				clientPod.Status.PodIP, int32(9003), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+			// cedric-diggory-1 is our client pod in hufflepuff namespace
+			// ensure ingress is DENIED from hufflepuff to ravenclaw for rest of the traffic; ingressRule at index6
+			success = kubernetes.PokeServer(t, "network-policy-conformance-hufflepuff", "cedric-diggory-1", "sctp",
+				clientPod.Status.PodIP, int32(9005), s.TimeoutConfig.RequestTimeout, false)
+			assert.Equal(t, true, success)
+		})
+
+		t.Run("Should support an 'deny-ingress' policy for SCTP protocol; ensure rule ordering is respected", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `ingress-sctp` ANP
+			// luna-lovegood-1 is our server pod in ravenclaw namespace
+			clientPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-ravenclaw",
+				Name:      "luna-lovegood-1",
+			}, clientPod)
+			framework.ExpectNoError(err, "unable to fetch the server pod")
+			anp := &v1alpha1.AdminNetworkPolicy{}
+			err = s.Client.Get(ctx, client.ObjectKey{
+				Name: "ingress-sctp",
+			}, anp)
+			framework.ExpectNoError(err, "unable to fetch the admin network policy")
+			// swap rules at index0 and index1
+			allowRule := anp.DeepCopy().Spec.Ingress[0]
+			anp.Spec.Ingress[0] = anp.DeepCopy().Spec.Ingress[1]
+			anp.Spec.Ingress[1] = allowRule
+			err = s.Client.Update(ctx, anp)
+			framework.ExpectNoError(err, "unable to update the admin network policy")
+			// harry-potter-0 is our client pod in gryffindor namespace
+			// ensure ingress is DENIED from gryffindor to ravenclaw
+			// ingressRule at index0 will take precedence over ingressRule at index1; thus DENY takes precedence over ALLOW since rules are ordered
+			success := kubernetes.PokeServer(t, "network-policy-conformance-gryffindor", "harry-potter-0", "sctp",
+				clientPod.Status.PodIP, int32(9003), s.TimeoutConfig.RequestTimeout, false)
+			assert.Equal(t, true, success)
+			// harry-potter-1 is our client pod in gryffindor namespace
+			success = kubernetes.PokeServer(t, "network-policy-conformance-gryffindor", "harry-potter-1", "sctp",
+				clientPod.Status.PodIP, int32(9005), s.TimeoutConfig.RequestTimeout, false)
+			assert.Equal(t, true, success)
+		})
+
+		t.Run("Should support a 'deny-ingress' policy for SCTP protocol at the specified port", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `ingress-sctp` ANP
+			// luna-lovegood-0 is our server pod in ravenclaw namespace
+			clientPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-ravenclaw",
+				Name:      "luna-lovegood-0",
+			}, clientPod)
+			framework.ExpectNoError(err, "unable to fetch the server pod")
+			// draco-malfoy-0 is our client pod in slytherin namespace
+			// ensure ingress from slytherin is DENIED to ravenclaw at port 9003; ingressRule at index3
+			success := kubernetes.PokeServer(t, "network-policy-conformance-slytherin", "draco-malfoy-0", "sctp",
+				clientPod.Status.PodIP, int32(9003), s.TimeoutConfig.RequestTimeout, false)
+			assert.Equal(t, true, success)
+			// draco-malfoy-1 is our client pod in slytherin namespace
+			// ensure ingress from slytherin is ALLOWED to ravenclaw for rest of the traffic; matches no rules hence allowed
+			success = kubernetes.PokeServer(t, "network-policy-conformance-slytherin", "draco-malfoy-1", "sctp",
+				clientPod.Status.PodIP, int32(9005), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+		})
+
+		t.Run("Should support an 'pass-ingress' policy for SCTP protocol; ensure rule ordering is respected", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `ingress-sctp` ANP
+			// luna-lovegood-1 is our server pod in ravenclaw namespace
+			clientPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-ravenclaw",
+				Name:      "luna-lovegood-1",
+			}, clientPod)
+			framework.ExpectNoError(err, "unable to fetch the server pod")
+			anp := &v1alpha1.AdminNetworkPolicy{}
+			err = s.Client.Get(ctx, client.ObjectKey{
+				Name: "ingress-sctp",
+			}, anp)
+			framework.ExpectNoError(err, "unable to fetch the admin network policy")
+			// swap rules at index0 and index2
+			denyRule := anp.DeepCopy().Spec.Ingress[0]
+			anp.Spec.Ingress[0] = anp.DeepCopy().Spec.Ingress[2]
+			anp.Spec.Ingress[2] = denyRule
+			err = s.Client.Update(ctx, anp)
+			framework.ExpectNoError(err, "unable to update the admin network policy")
+			// harry-potter-0 is our client pod in gryffindor namespace
+			// ensure ingress is PASSED from gryffindor to ravenclaw
+			// ingressRule at index0 will take precedence over ingressRule at index1&index2; thus PASS takes precedence over ALLOW/DENY since rules are ordered
+			success := kubernetes.PokeServer(t, "network-policy-conformance-gryffindor", "harry-potter-0", "sctp",
+				clientPod.Status.PodIP, int32(9003), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+			// harry-potter-1 is our client pod in gryffindor namespace
+			success = kubernetes.PokeServer(t, "network-policy-conformance-gryffindor", "harry-potter-1", "sctp",
+				clientPod.Status.PodIP, int32(9005), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+		})
+
+		t.Run("Should support a 'pass-ingress' policy for SCTP protocol at the specified port", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `ingress-sctp` ANP
+			// luna-lovegood-0 is our server pod in ravenclaw namespace
+			clientPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-ravenclaw",
+				Name:      "luna-lovegood-0",
+			}, clientPod)
+			framework.ExpectNoError(err, "unable to fetch the server pod")
+			anp := &v1alpha1.AdminNetworkPolicy{}
+			err = s.Client.Get(ctx, client.ObjectKey{
+				Name: "ingress-sctp",
+			}, anp)
+			framework.ExpectNoError(err, "unable to fetch the admin network policy")
+			// swap rules at index3 and index4
+			denyRule := anp.DeepCopy().Spec.Ingress[3]
+			anp.Spec.Ingress[3] = anp.DeepCopy().Spec.Ingress[4]
+			anp.Spec.Ingress[4] = denyRule
+			err = s.Client.Update(ctx, anp)
+			framework.ExpectNoError(err, "unable to update the admin network policy")
+			// draco-malfoy-0 is our client pod in slytherin namespace
+			// ensure ingress from slytherin is PASSED to ravenclaw at port 9003; ingressRule at index3
+			success := kubernetes.PokeServer(t, "network-policy-conformance-slytherin", "draco-malfoy-0", "sctp",
+				clientPod.Status.PodIP, int32(9003), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+			// draco-malfoy-1 is our client pod in slytherin namespace
+			// ensure ingress from slytherin is ALLOWED to ravenclaw for rest of the traffic; matches no rules hence allowed
+			success = kubernetes.PokeServer(t, "network-policy-conformance-slytherin", "draco-malfoy-1", "sctp",
+				clientPod.Status.PodIP, int32(9005), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+		})
+	},
+}

--- a/conformance/tests/admin-network-policy-core-ingress-sctp-rules_base.yaml
+++ b/conformance/tests/admin-network-policy-core-ingress-sctp-rules_base.yaml
@@ -1,0 +1,72 @@
+apiVersion: policy.networking.k8s.io/v1alpha1
+kind: AdminNetworkPolicy
+metadata:
+  name: ingress-sctp
+spec:
+  priority: 5
+  subject:
+    namespaces:
+      matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+  ingress:
+  - name: "allow-from-gryffindor-everything"
+    action: "Allow"
+    from:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: network-policy-conformance-gryffindor
+  - name: "deny-from-gryffindor-everything"
+    action: "Deny"
+    from:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: network-policy-conformance-gryffindor
+  - name: "pass-from-gryffindor-everything"
+    action: "Pass"
+    from:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: network-policy-conformance-gryffindor
+  - name: "deny-from-slytherin-at-port-9003"
+    action: "Deny"
+    from:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: network-policy-conformance-slytherin
+    ports:
+      - portNumber:
+          protocol: SCTP
+          port: 9003
+  - name: "pass-from-slytherin-at-port-9003"
+    action: "Pass"
+    from:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: network-policy-conformance-slytherin
+    ports:
+      - portNumber:
+          protocol: SCTP
+          port: 9003
+  - name: "allow-from-hufflepuff-at-port-9003"
+    action: "Allow"
+    from:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
+    ports:
+      - portNumber:
+          protocol: SCTP
+          port: 9003
+  - name: "deny-from-hufflepuff-everything-else"
+    action: "Deny"
+    from:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: network-policy-conformance-hufflepuff

--- a/conformance/tests/admin-network-policy-core-ingress-tcp-rules.go
+++ b/conformance/tests/admin-network-policy-core-ingress-tcp-rules.go
@@ -1,0 +1,218 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/network-policy-api/apis/v1alpha1"
+	"sigs.k8s.io/network-policy-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/network-policy-api/conformance/utils/suite"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests,
+		AdminNetworkPolicyIngressTCP,
+	)
+}
+
+var AdminNetworkPolicyIngressTCP = suite.ConformanceTest{
+	ShortName:   "AdminNetworkPolicyIngressTCP",
+	Description: "Tests support for ingress traffic (TCP protocol) using admin network policy API based on a server and client model",
+	Features: []suite.SupportedFeature{
+		suite.SupportAdminNetworkPolicy,
+	},
+	Manifests: []string{"tests/admin-network-policy-core-ingress-tcp-rules_base.yaml"},
+	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+
+		t.Run("Should support an 'allow-ingress' policy for TCP protocol; ensure rule ordering is respected", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `ingress-tcp` ANP
+			// harry-potter-0 is our server pod in gryffindor namespace
+			clientPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-gryffindor",
+				Name:      "harry-potter-0",
+			}, clientPod)
+			framework.ExpectNoError(err, "unable to fetch the server pod")
+			// luna-lovegood-0 is our client pod in ravenclaw namespace
+			// ensure ingress is ALLOWED from ravenclaw to gryffindor
+			// ingressRule at index0 will take precedence over ingressRule at index1; thus ALLOW takes precedence over DENY since rules are ordered
+			success := kubernetes.PokeServer(t, "network-policy-conformance-ravenclaw", "luna-lovegood-0", "tcp",
+				clientPod.Status.PodIP, int32(80), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+			success = kubernetes.PokeServer(t, "network-policy-conformance-ravenclaw", "luna-lovegood-1", "tcp",
+				clientPod.Status.PodIP, int32(8080), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+		})
+
+		t.Run("Should support an 'allow-ingress' policy for TCP protocol at the specified port", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `ingress-tcp` ANP
+			// harry-potter-1 is our server pod in gryffindor namespace
+			clientPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-gryffindor",
+				Name:      "harry-potter-1",
+			}, clientPod)
+			framework.ExpectNoError(err, "unable to fetch the server pod")
+			// cedric-diggory-0 is our client pod in hufflepuff namespace
+			// ensure ingress is ALLOWED from hufflepuff to gryffindor at port 80; ingressRule at index5
+			success := kubernetes.PokeServer(t, "network-policy-conformance-hufflepuff", "cedric-diggory-0", "tcp",
+				clientPod.Status.PodIP, int32(80), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+			// cedric-diggory-1 is our client pod in hufflepuff namespace
+			// ensure ingress is DENIED from hufflepuff to gryffindor for rest of the traffic; ingressRule at index6
+			success = kubernetes.PokeServer(t, "network-policy-conformance-hufflepuff", "cedric-diggory-1", "tcp",
+				clientPod.Status.PodIP, int32(8080), s.TimeoutConfig.RequestTimeout, false)
+			assert.Equal(t, true, success)
+		})
+
+		t.Run("Should support an 'deny-ingress' policy for TCP protocol; ensure rule ordering is respected", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `ingress-tcp` ANP
+			// harry-potter-1 is our server pod in gryffindor namespace
+			clientPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-gryffindor",
+				Name:      "harry-potter-1",
+			}, clientPod)
+			framework.ExpectNoError(err, "unable to fetch the server pod")
+			anp := &v1alpha1.AdminNetworkPolicy{}
+			err = s.Client.Get(ctx, client.ObjectKey{
+				Name: "ingress-tcp",
+			}, anp)
+			framework.ExpectNoError(err, "unable to fetch the admin network policy")
+			// swap rules at index0 and index1
+			allowRule := anp.DeepCopy().Spec.Ingress[0]
+			anp.Spec.Ingress[0] = anp.DeepCopy().Spec.Ingress[1]
+			anp.Spec.Ingress[1] = allowRule
+			err = s.Client.Update(ctx, anp)
+			framework.ExpectNoError(err, "unable to update the admin network policy")
+			// luna-lovegood-0 is our client pod in ravenclaw namespace
+			// ensure ingress is DENIED from ravenclaw to gryffindor
+			// ingressRule at index0 will take precedence over ingressRule at index1; thus DENY takes precedence over ALLOW since rules are ordered
+			success := kubernetes.PokeServer(t, "network-policy-conformance-ravenclaw", "luna-lovegood-0", "tcp",
+				clientPod.Status.PodIP, int32(80), s.TimeoutConfig.RequestTimeout, false)
+			assert.Equal(t, true, success)
+			// luna-lovegood-1 is our client pod in ravenclaw namespace
+			success = kubernetes.PokeServer(t, "network-policy-conformance-ravenclaw", "luna-lovegood-1", "tcp",
+				clientPod.Status.PodIP, int32(8080), s.TimeoutConfig.RequestTimeout, false)
+			assert.Equal(t, true, success)
+		})
+
+		t.Run("Should support a 'deny-ingress' policy for TCP protocol at the specified port", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `ingress-tcp` ANP
+			// harry-potter-0 is our server pod in gryffindor namespace
+			clientPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-gryffindor",
+				Name:      "harry-potter-0",
+			}, clientPod)
+			framework.ExpectNoError(err, "unable to fetch the server pod")
+			// draco-malfoy-0 is our client pod in slytherin namespace
+			// ensure ingress from slytherin is DENIED to gryffindor at port 80; ingressRule at index3
+			success := kubernetes.PokeServer(t, "network-policy-conformance-slytherin", "draco-malfoy-0", "tcp",
+				clientPod.Status.PodIP, int32(80), s.TimeoutConfig.RequestTimeout, false)
+			assert.Equal(t, true, success)
+			// draco-malfoy-1 is our client pod in slytherin namespace
+			// ensure ingress from slytherin is ALLOWED to gryffindor for rest of the traffic; matches no rules hence allowed
+			success = kubernetes.PokeServer(t, "network-policy-conformance-slytherin", "draco-malfoy-1", "tcp",
+				clientPod.Status.PodIP, int32(8080), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+		})
+
+		t.Run("Should support an 'pass-ingress' policy for TCP protocol; ensure rule ordering is respected", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `ingress-tcp` ANP
+			// harry-potter-0 is our server pod in gryffindor namespace
+			clientPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-gryffindor",
+				Name:      "harry-potter-0",
+			}, clientPod)
+			framework.ExpectNoError(err, "unable to fetch the server pod")
+			anp := &v1alpha1.AdminNetworkPolicy{}
+			err = s.Client.Get(ctx, client.ObjectKey{
+				Name: "ingress-tcp",
+			}, anp)
+			framework.ExpectNoError(err, "unable to fetch the admin network policy")
+			// swap rules at index0 and index2
+			denyRule := anp.DeepCopy().Spec.Ingress[0]
+			anp.Spec.Ingress[0] = anp.DeepCopy().Spec.Ingress[2]
+			anp.Spec.Ingress[2] = denyRule
+			err = s.Client.Update(ctx, anp)
+			framework.ExpectNoError(err, "unable to update the admin network policy")
+			// luna-lovegood-0 is our client pod in ravenclaw namespace
+			// ensure ingress is PASSED from ravenclaw to gryffindor
+			// ingressRule at index0 will take precedence over ingressRule at index1&index2; thus PASS takes precedence over ALLOW/DENY since rules are ordered
+			success := kubernetes.PokeServer(t, "network-policy-conformance-ravenclaw", "luna-lovegood-0", "tcp",
+				clientPod.Status.PodIP, int32(80), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+			// luna-lovegood-1 is our client pod in ravenclaw namespace
+			success = kubernetes.PokeServer(t, "network-policy-conformance-ravenclaw", "luna-lovegood-1", "tcp",
+				clientPod.Status.PodIP, int32(8080), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+		})
+
+		t.Run("Should support a 'pass-ingress' policy for TCP protocol at the specified port", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `ingress-tcp` ANP
+			// harry-potter-0 is our server pod in gryffindor namespace
+			clientPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-gryffindor",
+				Name:      "harry-potter-0",
+			}, clientPod)
+			framework.ExpectNoError(err, "unable to fetch the server pod")
+			anp := &v1alpha1.AdminNetworkPolicy{}
+			err = s.Client.Get(ctx, client.ObjectKey{
+				Name: "ingress-tcp",
+			}, anp)
+			framework.ExpectNoError(err, "unable to fetch the admin network policy")
+			// swap rules at index3 and index4
+			denyRule := anp.DeepCopy().Spec.Ingress[3]
+			anp.Spec.Ingress[3] = anp.DeepCopy().Spec.Ingress[4]
+			anp.Spec.Ingress[4] = denyRule
+			err = s.Client.Update(ctx, anp)
+			framework.ExpectNoError(err, "unable to update the admin network policy")
+			// draco-malfoy-0 is our client pod in slytherin namespace
+			// ensure ingress from slytherin is PASSED to gryffindor at port 9003; ingressRule at index3
+			success := kubernetes.PokeServer(t, "network-policy-conformance-slytherin", "draco-malfoy-0", "tcp",
+				clientPod.Status.PodIP, int32(80), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+			// draco-malfoy-1 is our client pod in slytherin namespace
+			// ensure ingress from slytherin is ALLOWED to gryffindor for rest of the traffic; matches no rules hence allowed
+			success = kubernetes.PokeServer(t, "network-policy-conformance-slytherin", "draco-malfoy-1", "tcp",
+				clientPod.Status.PodIP, int32(8080), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+		})
+	},
+}

--- a/conformance/tests/admin-network-policy-core-ingress-tcp-rules_base.yaml
+++ b/conformance/tests/admin-network-policy-core-ingress-tcp-rules_base.yaml
@@ -1,0 +1,72 @@
+apiVersion: policy.networking.k8s.io/v1alpha1
+kind: AdminNetworkPolicy
+metadata:
+  name: ingress-tcp
+spec:
+  priority: 3
+  subject:
+    namespaces:
+      matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-gryffindor
+  ingress:
+  - name: "allow-from-ravenclaw-everything"
+    action: "Allow"
+    from:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+  - name: "deny-from-ravenclaw-everything"
+    action: "Deny"
+    from:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+  - name: "pass-from-ravenclaw-everything"
+    action: "Pass"
+    from:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+  - name: "deny-from-slytherin-at-port-80"
+    action: "Deny"
+    from:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: network-policy-conformance-slytherin
+    ports:
+      - portNumber:
+          protocol: TCP
+          port: 80
+  - name: "pass-from-slytherin-at-port-80"
+    action: "Pass"
+    from:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: network-policy-conformance-slytherin
+    ports:
+      - portNumber:
+          protocol: TCP
+          port: 80
+  - name: "allow-from-hufflepuff-at-port-80"
+    action: "Allow"
+    from:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
+    ports:
+      - portNumber:
+          protocol: TCP
+          port: 80
+  - name: "deny-from-hufflepuff-everything-else"
+    action: "Deny"
+    from:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: network-policy-conformance-hufflepuff

--- a/conformance/tests/admin-network-policy-core-ingress-udp-rules.go
+++ b/conformance/tests/admin-network-policy-core-ingress-udp-rules.go
@@ -1,0 +1,218 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/network-policy-api/apis/v1alpha1"
+	"sigs.k8s.io/network-policy-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/network-policy-api/conformance/utils/suite"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests,
+		AdminNetworkPolicyIngressUDP,
+	)
+}
+
+var AdminNetworkPolicyIngressUDP = suite.ConformanceTest{
+	ShortName:   "AdminNetworkPolicyIngressUDP",
+	Description: "Tests support for ingress traffic (UDP protocol) using admin network policy API based on a server and client model",
+	Features: []suite.SupportedFeature{
+		suite.SupportAdminNetworkPolicy,
+	},
+	Manifests: []string{"tests/admin-network-policy-core-ingress-udp-rules_base.yaml"},
+	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+
+		t.Run("Should support an 'allow-ingress' policy for UDP protocol; ensure rule ordering is respected", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `ingress-udp` ANP
+			// cedric-diggory-0 is our server pod in hufflepuff namespace
+			clientPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-hufflepuff",
+				Name:      "cedric-diggory-0",
+			}, clientPod)
+			framework.ExpectNoError(err, "unable to fetch the server pod")
+			// luna-lovegood-0 is our client pod in ravenclaw namespace
+			// ensure ingress is ALLOWED from ravenclaw to hufflepuff
+			// ingressRule at index0 will take precedence over ingressRule at index1; thus ALLOW takes precedence over DENY since rules are ordered
+			success := kubernetes.PokeServer(t, "network-policy-conformance-ravenclaw", "luna-lovegood-0", "udp",
+				clientPod.Status.PodIP, int32(53), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+			success = kubernetes.PokeServer(t, "network-policy-conformance-ravenclaw", "luna-lovegood-1", "udp",
+				clientPod.Status.PodIP, int32(5353), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+		})
+
+		t.Run("Should support an 'allow-ingress' policy for UDP protocol at the specified port", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `ingress-udp` ANP
+			// cedric-diggory-1 is our server pod in hufflepuff namespace
+			clientPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-hufflepuff",
+				Name:      "cedric-diggory-1",
+			}, clientPod)
+			framework.ExpectNoError(err, "unable to fetch the server pod")
+			// harry-potter-0 is our client pod in gryffindor namespace
+			// ensure ingress is ALLOWED from gryffindor to hufflepuff at port 53; ingressRule at index5
+			success := kubernetes.PokeServer(t, "network-policy-conformance-gryffindor", "harry-potter-0", "udp",
+				clientPod.Status.PodIP, int32(53), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+			// harry-potter-1 is our client pod in gryfindor namespace
+			// ensure ingress is DENIED from gryffindor to hufflepuff for rest of the traffic; ingressRule at index6
+			success = kubernetes.PokeServer(t, "network-policy-conformance-gryffindor", "harry-potter-1", "udp",
+				clientPod.Status.PodIP, int32(5353), s.TimeoutConfig.RequestTimeout, false)
+			assert.Equal(t, true, success)
+		})
+
+		t.Run("Should support an 'deny-ingress' policy for UDP protocol; ensure rule ordering is respected", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `ingress-udp` ANP
+			// cedric-diggory-1 is our server pod in hufflepuff namespace
+			clientPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-hufflepuff",
+				Name:      "cedric-diggory-1",
+			}, clientPod)
+			framework.ExpectNoError(err, "unable to fetch the server pod")
+			anp := &v1alpha1.AdminNetworkPolicy{}
+			err = s.Client.Get(ctx, client.ObjectKey{
+				Name: "ingress-udp",
+			}, anp)
+			framework.ExpectNoError(err, "unable to fetch the admin network policy")
+			// swap rules at index0 and index1
+			allowRule := anp.DeepCopy().Spec.Ingress[0]
+			anp.Spec.Ingress[0] = anp.DeepCopy().Spec.Ingress[1]
+			anp.Spec.Ingress[1] = allowRule
+			err = s.Client.Update(ctx, anp)
+			framework.ExpectNoError(err, "unable to update the admin network policy")
+			// luna-lovegood-0 is our client pod in ravenclaw namespace
+			// ensure ingress is DENIED from ravenclaw to hufflepuff
+			// ingressRule at index0 will take precedence over ingressRule at index1; thus DENY takes precedence over ALLOW since rules are ordered
+			success := kubernetes.PokeServer(t, "network-policy-conformance-ravenclaw", "luna-lovegood-0", "udp",
+				clientPod.Status.PodIP, int32(53), s.TimeoutConfig.RequestTimeout, false)
+			assert.Equal(t, true, success)
+			// luna-lovegood-1 is our client pod in ravenclaw namespace
+			success = kubernetes.PokeServer(t, "network-policy-conformance-ravenclaw", "luna-lovegood-1", "udp",
+				clientPod.Status.PodIP, int32(5353), s.TimeoutConfig.RequestTimeout, false)
+			assert.Equal(t, true, success)
+		})
+
+		t.Run("Should support a 'deny-ingress' policy for UDP protocol at the specified port", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `ingress-udp` ANP
+			// cedric-diggory-0 is our server pod in hufflepuff namespace
+			clientPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-hufflepuff",
+				Name:      "cedric-diggory-0",
+			}, clientPod)
+			framework.ExpectNoError(err, "unable to fetch the server pod")
+			// draco-malfoy-0 is our client pod in slytherin namespace
+			// ensure ingress from slytherin is DENIED to hufflepuff at port 80; ingressRule at index3
+			success := kubernetes.PokeServer(t, "network-policy-conformance-slytherin", "draco-malfoy-0", "udp",
+				clientPod.Status.PodIP, int32(5353), s.TimeoutConfig.RequestTimeout, false)
+			assert.Equal(t, true, success)
+			// draco-malfoy-1 is our client pod in slytherin namespace
+			// ensure ingress from slytherin is ALLOWED to hufflepuff for rest of the traffic; matches no rules hence allowed
+			success = kubernetes.PokeServer(t, "network-policy-conformance-slytherin", "draco-malfoy-1", "udp",
+				clientPod.Status.PodIP, int32(53), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+		})
+
+		t.Run("Should support an 'pass-ingress' policy for UDP protocol; ensure rule ordering is respected", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `ingress-udp` ANP
+			// cedric-diggory-1 is our server pod in hufflepuff namespace
+			clientPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-hufflepuff",
+				Name:      "cedric-diggory-1",
+			}, clientPod)
+			framework.ExpectNoError(err, "unable to fetch the server pod")
+			anp := &v1alpha1.AdminNetworkPolicy{}
+			err = s.Client.Get(ctx, client.ObjectKey{
+				Name: "ingress-udp",
+			}, anp)
+			framework.ExpectNoError(err, "unable to fetch the admin network policy")
+			// swap rules at index0 and index2
+			denyRule := anp.DeepCopy().Spec.Ingress[0]
+			anp.Spec.Ingress[0] = anp.DeepCopy().Spec.Ingress[2]
+			anp.Spec.Ingress[2] = denyRule
+			err = s.Client.Update(ctx, anp)
+			framework.ExpectNoError(err, "unable to update the admin network policy")
+			// luna-lovegood-0 is our client pod in ravenclaw namespace
+			// ensure ingress is PASSED from ravenclaw to hufflepuff
+			// ingressRule at index0 will take precedence over ingressRule at index1&index2; thus PASS takes precedence over ALLOW/DENY since rules are ordered
+			success := kubernetes.PokeServer(t, "network-policy-conformance-ravenclaw", "luna-lovegood-0", "udp",
+				clientPod.Status.PodIP, int32(5353), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+			// luna-lovegood-1 is our client pod in ravenclaw namespace
+			success = kubernetes.PokeServer(t, "network-policy-conformance-ravenclaw", "luna-lovegood-1", "udp",
+				clientPod.Status.PodIP, int32(53), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+		})
+
+		t.Run("Should support a 'pass-ingress' policy for UDP protocol at the specified port", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `ingress-udp` ANP
+			// cedric-diggory-0 is our server pod in hufflepuff namespace
+			clientPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-hufflepuff",
+				Name:      "cedric-diggory-0",
+			}, clientPod)
+			framework.ExpectNoError(err, "unable to fetch the server pod")
+			anp := &v1alpha1.AdminNetworkPolicy{}
+			err = s.Client.Get(ctx, client.ObjectKey{
+				Name: "ingress-udp",
+			}, anp)
+			framework.ExpectNoError(err, "unable to fetch the admin network policy")
+			// swap rules at index3 and index4
+			denyRule := anp.DeepCopy().Spec.Ingress[3]
+			anp.Spec.Ingress[3] = anp.DeepCopy().Spec.Ingress[4]
+			anp.Spec.Ingress[4] = denyRule
+			err = s.Client.Update(ctx, anp)
+			framework.ExpectNoError(err, "unable to update the admin network policy")
+			// draco-malfoy-0 is our client pod in slytherin namespace
+			// ensure ingress from slytherin is PASSED to hufflepuff at port 5353; ingressRule at index3
+			success := kubernetes.PokeServer(t, "network-policy-conformance-slytherin", "draco-malfoy-0", "udp",
+				clientPod.Status.PodIP, int32(5353), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+			// draco-malfoy-1 is our client pod in slytherin namespace
+			// ensure ingress from slytherin is ALLOWED to hufflepuff for rest of the traffic; matches no rules hence allowed
+			success = kubernetes.PokeServer(t, "network-policy-conformance-slytherin", "draco-malfoy-1", "udp",
+				clientPod.Status.PodIP, int32(53), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+		})
+	},
+}

--- a/conformance/tests/admin-network-policy-core-ingress-udp-rules_base.yaml
+++ b/conformance/tests/admin-network-policy-core-ingress-udp-rules_base.yaml
@@ -1,0 +1,72 @@
+apiVersion: policy.networking.k8s.io/v1alpha1
+kind: AdminNetworkPolicy
+metadata:
+  name: ingress-udp
+spec:
+  priority: 4
+  subject:
+    namespaces:
+      matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
+  ingress:
+  - name: "allow-from-ravenclaw-everything"
+    action: "Allow"
+    from:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+  - name: "deny-from-ravenclaw-everything"
+    action: "Deny"
+    from:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+  - name: "pass-from-ravenclaw-everything"
+    action: "Pass"
+    from:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+  - name: "deny-from-slytherin-at-port-5353"
+    action: "Deny"
+    from:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: network-policy-conformance-slytherin
+    ports:
+      - portNumber:
+          protocol: UDP
+          port: 5353
+  - name: "pass-from-slytherin-at-port-5353"
+    action: "Pass"
+    from:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: network-policy-conformance-slytherin
+    ports:
+      - portNumber:
+          protocol: UDP
+          port: 5353
+  - name: "allow-from-gryffindor-at-port-53"
+    action: "Allow"
+    from:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: network-policy-conformance-gryffindor
+    ports:
+      - portNumber:
+          protocol: UDP
+          port: 53
+  - name: "deny-from-gryffindor-everything-else"
+    action: "Deny"
+    from:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: network-policy-conformance-gryffindor

--- a/conformance/utils/kubernetes/helper.go
+++ b/conformance/utils/kubernetes/helper.go
@@ -2,6 +2,8 @@ package kubernetes
 
 import (
 	"context"
+	"fmt"
+	"net"
 	"strings"
 	"testing"
 	"time"
@@ -9,10 +11,63 @@ import (
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/network-policy-api/conformance/utils/config"
 )
+
+// PokeServer is a utility function that checks if the connection from the provided clientPod in clientNamespace towards the targetHost:targetPort
+// using the provided protocol can be established or not and returns the result based on if the expectation is shouldConnect or !shouldConnect
+func PokeServer(t *testing.T, clientNamespace, clientPod, protocol, targetHost string, targetPort int32, timeout time.Duration, shouldConnect bool) bool {
+	t.Helper()
+	cmd := []string{"exec", clientPod, "--"} // command is to be run inside a pod
+	timeoutArg := fmt.Sprintf("--timeout=%v", timeout)
+	protocolArg := fmt.Sprintf("--protocol=%s", protocol)
+	ipPortArg := net.JoinHostPort(targetHost, fmt.Sprintf("%d", targetPort))
+
+	// we leverage the dial connect from agnhost, that is already supporting multiple protocols
+	connectCommand := strings.Split(fmt.Sprintf("/agnhost connect %s %s %s",
+		timeoutArg,
+		protocolArg,
+		ipPortArg), " ")
+
+	cmd = append(cmd, connectCommand...)
+	var res string
+	var err error
+	res, err = e2ekubectl.RunKubectl(clientNamespace, cmd...)
+	// TODO(tssurya): Improve the error matching to be more specific (https://pkg.go.dev/k8s.io/kubernetes/test/images/agnhost#readme-connect)
+	// A connection error looks like this and we need to improve the parsing to be more accurate:
+	// Command stdout:
+	// stderr:
+	// TIMEOUT
+	// command terminated with exit code 1
+	// error:
+	// exit status 1
+	// TODO(tssurya): See if we need to add a wait&retry mechanism to test connectivity
+	// See https://github.com/kubernetes-sigs/network-policy-api/issues/108 for details.
+	if shouldConnect && (err != nil || len(res) > 0) {
+		framework.Logf("FAILED Command was %s", connectCommand)
+		framework.Logf("FAILED Response was %v, expected connection to succeed from %s to %s, "+
+			"but instead it miserably failed: %v", res, clientPod, targetHost, err.Error())
+		return false
+	} else if !shouldConnect {
+		if err == nil && len(res) == 0 {
+			framework.Logf("FAILED Command was %s", connectCommand)
+			framework.Logf("FAILED Response was %v, expected connection to fail from %s to %s, "+
+				"but instead it successfully connected", res, clientPod, targetHost)
+			return false
+		} else if strings.Contains(err.Error(), "TIMEOUT") {
+			framework.Logf("error contained 'TIMEOUT', as expected: %s", err.Error())
+			return true
+		} else {
+			framework.Logf("error didn't contain 'TIMEOUT', as expected: %s", err.Error())
+			return false
+		}
+	}
+	return true
+}
 
 // NamespacesMustBeReady waits until all Pods are marked Ready. This will
 // cause the test to halt if the specified timeout is exceeded.


### PR DESCRIPTION
This PR adds conformance for ingress rules and egress rules with 3 actions deny/allow/pass across all 3 protocols udp/sctp/tcp with and without ports.
A new suite of tests will be added for mix of both ingress & egress rules called gressRules with mix of protocols in a new PR.
Depends on https://github.com/kubernetes-sigs/network-policy-api/pull/98
Sample Output:
```
--- PASS: TestConformance (92.63s)                                                                                                                                           
    --- PASS: TestConformance/AdminNetworkPolicyEgressSCTP (15.02s)                                                                                                          
        --- PASS: TestConformance/AdminNetworkPolicyEgressSCTP/Should_support_an_'allow-egress'_policy_for_SCTP_protocol;_ensure_rule_ordering_is_respected (0.80s)          
        --- PASS: TestConformance/AdminNetworkPolicyEgressSCTP/Should_support_an_'allow-egress'_policy_for_SCTP_protocol_at_the_specified_port (3.41s)                       
        --- PASS: TestConformance/AdminNetworkPolicyEgressSCTP/Should_support_an_'deny-egress'_policy_for_SCTP_protocol;_ensure_rule_ordering_is_respected (6.56s)           
        --- PASS: TestConformance/AdminNetworkPolicyEgressSCTP/Should_support_a_'deny-egress'_policy_for_SCTP_protocol_at_the_specified_port (3.55s)                         
        --- PASS: TestConformance/AdminNetworkPolicyEgressSCTP/Should_support_an_'pass-egress'_policy_for_SCTP_protocol;_ensure_rule_ordering_is_respected (0.34s)           
        --- PASS: TestConformance/AdminNetworkPolicyEgressSCTP/Should_support_a_'pass-egress'_policy_for_SCTP_protocol_at_the_specified_port (0.32s)                         
    --- PASS: TestConformance/AdminNetworkPolicyEgressTCP (14.03s)                                                                                                           
        --- PASS: TestConformance/AdminNetworkPolicyEgressTCP/Should_support_an_'allow-egress'_policy_for_TCP_protocol;_ensure_rule_ordering_is_respected (0.22s)            
        --- PASS: TestConformance/AdminNetworkPolicyEgressTCP/Should_support_an_'allow-egress'_policy_for_TCP_protocol_at_the_specified_port (3.22s)                         
        --- PASS: TestConformance/AdminNetworkPolicyEgressTCP/Should_support_an_'deny-egress'_policy_for_TCP_protocol;_ensure_rule_ordering_is_respected (6.55s)             
        --- PASS: TestConformance/AdminNetworkPolicyEgressTCP/Should_support_a_'deny-egress'_policy_for_TCP_protocol_at_the_specified_port (3.48s)                           
        --- PASS: TestConformance/AdminNetworkPolicyEgressTCP/Should_support_an_'pass-egress'_policy_for_TCP_protocol;_ensure_rule_ordering_is_respected (0.27s)             
        --- PASS: TestConformance/AdminNetworkPolicyEgressTCP/Should_support_a_'pass-egress'_policy_for_TCP_protocol_at_the_specified_port (0.28s)                           
    --- PASS: TestConformance/AdminNetworkPolicyEgressUDP (14.26s)                                                                                                           
        --- PASS: TestConformance/AdminNetworkPolicyEgressUDP/Should_support_an_'allow-egress'_policy_for_UDP_protocol;_ensure_rule_ordering_is_respected (0.25s)            
        --- PASS: TestConformance/AdminNetworkPolicyEgressUDP/Should_support_an_'allow-egress'_policy_for_UDP_protocol_at_the_specified_port (3.19s)                         
        --- PASS: TestConformance/AdminNetworkPolicyEgressUDP/Should_support_an_'deny-egress'_policy_for_UDP_protocol;_ensure_rule_ordering_is_respected (6.37s)             
        --- PASS: TestConformance/AdminNetworkPolicyEgressUDP/Should_support_a_'deny-egress'_policy_for_UDP_protocol_at_the_specified_port (3.60s)                           
        --- PASS: TestConformance/AdminNetworkPolicyEgressUDP/Should_support_an_'pass-egress'_policy_for_UDP_protocol;_ensure_rule_ordering_is_respected (0.42s)             
        --- PASS: TestConformance/AdminNetworkPolicyEgressUDP/Should_support_a_'pass-egress'_policy_for_UDP_protocol_at_the_specified_port (0.39s)
    --- PASS: TestConformance/AdminNetworkPolicyIngressSCTP (14.34s)                                                                                                         
        --- PASS: TestConformance/AdminNetworkPolicyIngressSCTP/Should_support_an_'allow-ingress'_policy_for_SCTP_protocol;_ensure_rule_ordering_is_respected (0.35s)
        --- PASS: TestConformance/AdminNetworkPolicyIngressSCTP/Should_support_an_'allow-ingress'_policy_for_SCTP_protocol_at_the_specified_port (3.23s)                     
        --- PASS: TestConformance/AdminNetworkPolicyIngressSCTP/Should_support_an_'deny-ingress'_policy_for_SCTP_protocol;_ensure_rule_ordering_is_respected (6.46s) 
        --- PASS: TestConformance/AdminNetworkPolicyIngressSCTP/Should_support_a_'deny-ingress'_policy_for_SCTP_protocol_at_the_specified_port (3.57s)  
        --- PASS: TestConformance/AdminNetworkPolicyIngressSCTP/Should_support_an_'pass-ingress'_policy_for_SCTP_protocol;_ensure_rule_ordering_is_respected (0.41s)         
        --- PASS: TestConformance/AdminNetworkPolicyIngressSCTP/Should_support_a_'pass-ingress'_policy_for_SCTP_protocol_at_the_specified_port (0.30s)                       
    --- PASS: TestConformance/AdminNetworkPolicyIngressTCP (14.40s)                                                                                                          
        --- PASS: TestConformance/AdminNetworkPolicyIngressTCP/Should_support_an_'allow-ingress'_policy_for_TCP_protocol;_ensure_rule_ordering_is_respected (0.23s)          
        --- PASS: TestConformance/AdminNetworkPolicyIngressTCP/Should_support_an_'allow-ingress'_policy_for_TCP_protocol_at_the_specified_port (3.21s)
        --- PASS: TestConformance/AdminNetworkPolicyIngressTCP/Should_support_an_'deny-ingress'_policy_for_TCP_protocol;_ensure_rule_ordering_is_respected (6.57s)           
        --- PASS: TestConformance/AdminNetworkPolicyIngressTCP/Should_support_a_'deny-ingress'_policy_for_TCP_protocol_at_the_specified_port (3.69s)                         
        --- PASS: TestConformance/AdminNetworkPolicyIngressTCP/Should_support_an_'pass-ingress'_policy_for_TCP_protocol;_ensure_rule_ordering_is_respected (0.41s)           
        --- PASS: TestConformance/AdminNetworkPolicyIngressTCP/Should_support_a_'pass-ingress'_policy_for_TCP_protocol_at_the_specified_port (0.27s)
    --- PASS: TestConformance/AdminNetworkPolicyIngressUDP (14.26s)                                                                                                          
        --- PASS: TestConformance/AdminNetworkPolicyIngressUDP/Should_support_an_'allow-ingress'_policy_for_UDP_protocol;_ensure_rule_ordering_is_respected (0.24s)
        --- PASS: TestConformance/AdminNetworkPolicyIngressUDP/Should_support_an_'allow-ingress'_policy_for_UDP_protocol_at_the_specified_port (3.23s)
        --- PASS: TestConformance/AdminNetworkPolicyIngressUDP/Should_support_an_'deny-ingress'_policy_for_UDP_protocol;_ensure_rule_ordering_is_respected (6.55s)
        --- PASS: TestConformance/AdminNetworkPolicyIngressUDP/Should_support_a_'deny-ingress'_policy_for_UDP_protocol_at_the_specified_port (3.47s)
        --- PASS: TestConformance/AdminNetworkPolicyIngressUDP/Should_support_an_'pass-ingress'_policy_for_UDP_protocol;_ensure_rule_ordering_is_respected (0.38s)
        --- PASS: TestConformance/AdminNetworkPolicyIngressUDP/Should_support_a_'pass-ingress'_policy_for_UDP_protocol_at_the_specified_port (0.37s)
PASS
```