### PR TITLE
Add conformance integration tests between ANP/NP/BANP

### DIFF
--- a/conformance/tests/admin-network-policy-core-integration.go
+++ b/conformance/tests/admin-network-policy-core-integration.go
@@ -1,0 +1,214 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/network-policy-api/apis/v1alpha1"
+	"sigs.k8s.io/network-policy-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/network-policy-api/conformance/utils/suite"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests,
+		AdminNetworkPolicyIntegration,
+	)
+}
+
+var AdminNetworkPolicyIntegration = suite.ConformanceTest{
+	ShortName:   "AdminNetworkPolicyIntegration",
+	Description: "Tests integration support for gress traffic between ANP, NP and BANP using PASS action based on a server and client model",
+	Features: []suite.SupportedFeature{
+		suite.SupportAdminNetworkPolicy,
+	},
+	Manifests: []string{"tests/admin-network-policy-core-integration_base.yaml"},
+	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+
+		t.Run("Should Deny traffic from slytherin to gryffindor respecting ANP", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `pass-example` ANP
+			// harry-potter-0 is our server pod in gryffindor namespace
+			clientPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-gryffindor",
+				Name:      "harry-potter-0",
+			}, clientPod)
+			framework.ExpectNoError(err, "unable to fetch the server pod")
+			// draco-malfoy-0 is our client pod in slytherin namespace
+			// ensure ingress is DENIED to gryffindor from slytherin
+			// inressRule at index0 will take effect
+			success := kubernetes.PokeServer(t, "network-policy-conformance-slytherin", "draco-malfoy-0", "tcp",
+				clientPod.Status.PodIP, int32(80), s.TimeoutConfig.RequestTimeout, false)
+			assert.Equal(t, true, success)
+			// draco-malfoy-1 is our client pod in slytherin namespace
+			success = kubernetes.PokeServer(t, "network-policy-conformance-slytherin", "draco-malfoy-1", "tcp",
+				clientPod.Status.PodIP, int32(8080), s.TimeoutConfig.RequestTimeout, false)
+			assert.Equal(t, true, success)
+		})
+
+		t.Run("Should Deny traffic to slytherin from gryffindor respecting ANP", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `pass-example` ANP
+			// draco-malfoy-0 is our server pod in slytherin namespace
+			clientPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-slytherin",
+				Name:      "draco-malfoy-0",
+			}, clientPod)
+			framework.ExpectNoError(err, "unable to fetch the server pod")
+			// harry-potter-0 is our client pod in gryffindor namespace
+			// ensure ingress is DENIED to gryffindor from slytherin
+			// egressRule at index0 will take effect
+			success := kubernetes.PokeServer(t, "network-policy-conformance-gryffindor", "harry-potter-0", "tcp",
+				clientPod.Status.PodIP, int32(80), s.TimeoutConfig.RequestTimeout, false)
+			assert.Equal(t, true, success)
+			// harry-potter-1 is our client pod in gryffindor namespace
+			success = kubernetes.PokeServer(t, "network-policy-conformance-gryffindor", "harry-potter-1", "tcp",
+				clientPod.Status.PodIP, int32(8080), s.TimeoutConfig.RequestTimeout, false)
+			assert.Equal(t, true, success)
+		})
+
+		t.Run("Should support a 'pass-ingress' policy for ANP and respect the match for network policy", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `pass example` ANP
+			anp := &v1alpha1.AdminNetworkPolicy{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Name: "pass-example",
+			}, anp)
+			framework.ExpectNoError(err, "unable to fetch the admin network policy")
+			// change ingress rule from "deny" to "pass"
+			anp.Spec.Ingress[0].Action = v1alpha1.AdminNetworkPolicyRuleActionPass
+			err = s.Client.Update(ctx, anp)
+			framework.ExpectNoError(err, "unable to update the admin network policy")
+			// harry-potter-0 is our server pod in gryffindor namespace
+			clientPod := &v1.Pod{}
+			err = s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-gryffindor",
+				Name:      "harry-potter-0",
+			}, clientPod)
+			framework.ExpectNoError(err, "unable to fetch the server pod")
+			// draco-malfoy-0 is our client pod in slytherin namespace
+			// ensure ingress is PASSED to gryffindor from slytherin - the network policy ALLOW should take effect
+			// inressRule at index0 will take effect
+			success := kubernetes.PokeServer(t, "network-policy-conformance-slytherin", "draco-malfoy-0", "tcp",
+				clientPod.Status.PodIP, int32(80), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+			// draco-malfoy-1 is our client pod in slytherin namespace
+			success = kubernetes.PokeServer(t, "network-policy-conformance-slytherin", "draco-malfoy-1", "tcp",
+				clientPod.Status.PodIP, int32(8080), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+		})
+
+		t.Run("Should support a 'pass-egress' policy for ANP and respect the match for network policy", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `pass example` ANP
+			anp := &v1alpha1.AdminNetworkPolicy{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Name: "pass-example",
+			}, anp)
+			framework.ExpectNoError(err, "unable to fetch the admin network policy")
+			// change egress rule from "deny" to "pass"
+			anp.Spec.Egress[0].Action = v1alpha1.AdminNetworkPolicyRuleActionPass
+			err = s.Client.Update(ctx, anp)
+			framework.ExpectNoError(err, "unable to update the admin network policy")
+			// draco-malfoy-0 is our server pod in slytherin namespace
+			clientPod := &v1.Pod{}
+			err = s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-slytherin",
+				Name:      "draco-malfoy-0",
+			}, clientPod)
+			framework.ExpectNoError(err, "unable to fetch the server pod")
+			// harry-potter-0 is our client pod in gryffindor namespace
+			// ensure ingress is PASSED to gryffindor from slytherin - the underlying network policy ALLOW should take effect
+			// egressRule at index0 will take effect
+			success := kubernetes.PokeServer(t, "network-policy-conformance-gryffindor", "harry-potter-0", "tcp",
+				clientPod.Status.PodIP, int32(80), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+			// harry-potter-1 is our client pod in gryffindor namespace
+			success = kubernetes.PokeServer(t, "network-policy-conformance-gryffindor", "harry-potter-1", "tcp",
+				clientPod.Status.PodIP, int32(8080), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+		})
+
+		t.Run("Should support a 'pass-ingress' policy for ANP and respect the match for baseline admin network policy", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `default` BANP
+			np := &networkingv1.NetworkPolicy{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-gryffindor",
+				Name:      "allow-gress-from-to-slytherin-to-gryffindor",
+			}, np)
+			framework.ExpectNoError(err, "unable to fetch the network policy")
+			// delete network policy so that BANP takes effect
+			err = s.Client.Delete(ctx, np)
+			framework.ExpectNoError(err, "unable to delete the network policy")
+			// harry-potter-0 is our server pod in gryffindor namespace
+			clientPod := &v1.Pod{}
+			err = s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-gryffindor",
+				Name:      "harry-potter-0",
+			}, clientPod)
+			framework.ExpectNoError(err, "unable to fetch the server pod")
+			// draco-malfoy-0 is our client pod in slytherin namespace
+			// ensure ingress is PASSED to gryffindor from slytherin - the baseline admin network policy DENY should take effect
+			// inressRule at index0 will take effect
+			success := kubernetes.PokeServer(t, "network-policy-conformance-slytherin", "draco-malfoy-0", "tcp",
+				clientPod.Status.PodIP, int32(80), s.TimeoutConfig.RequestTimeout, false)
+			assert.Equal(t, true, success)
+			// draco-malfoy-1 is our client pod in slytherin namespace
+			success = kubernetes.PokeServer(t, "network-policy-conformance-slytherin", "draco-malfoy-1", "tcp",
+				clientPod.Status.PodIP, int32(8080), s.TimeoutConfig.RequestTimeout, false)
+			assert.Equal(t, true, success)
+		})
+
+		t.Run("Should support a 'pass-egress' policy for ANP and respect the match for baseline admin network policy", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `default` BANP
+			// draco-malfoy-0 is our server pod in slytherin namespace
+			clientPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-slytherin",
+				Name:      "draco-malfoy-0",
+			}, clientPod)
+			framework.ExpectNoError(err, "unable to fetch the server pod")
+			// harry-potter-0 is our client pod in gryffindor namespace
+			// ensure ingress is PASSED to gryffindor from slytherin - the underlying baseline admin network policy DENY should take effect
+			// egressRule at index0 will take effect
+			success := kubernetes.PokeServer(t, "network-policy-conformance-gryffindor", "harry-potter-0", "tcp",
+				clientPod.Status.PodIP, int32(80), s.TimeoutConfig.RequestTimeout, false)
+			assert.Equal(t, true, success)
+			// harry-potter-1 is our client pod in gryffindor namespace
+			success = kubernetes.PokeServer(t, "network-policy-conformance-gryffindor", "harry-potter-1", "tcp",
+				clientPod.Status.PodIP, int32(8080), s.TimeoutConfig.RequestTimeout, false)
+			assert.Equal(t, true, success)
+		})
+	},
+}

--- a/conformance/tests/admin-network-policy-core-integration_base.yaml
+++ b/conformance/tests/admin-network-policy-core-integration_base.yaml
@@ -1,0 +1,73 @@
+apiVersion: policy.networking.k8s.io/v1alpha1
+kind: AdminNetworkPolicy
+metadata:
+  name: pass-example
+spec:
+  priority: 10
+  subject:
+    namespaces:
+      matchLabels:
+          conformance-house: gryffindor
+  ingress:
+  - name: "deny-all-ingress-from-slytherin" # test will update to pass
+    action: "Deny" # test will update to pass
+    from:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            conformance-house: slytherin
+  egress:
+  - name: "deny-all-egress-from-slytherin" # test will update to pass
+    action: "Deny" # test will update to pass
+    to:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            conformance-house: slytherin
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-gress-from-to-slytherin-to-gryffindor
+  namespace: network-policy-conformance-gryffindor
+spec:
+  podSelector:
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          conformance-house: slytherin
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          conformance-house: slytherin
+---
+apiVersion: policy.networking.k8s.io/v1alpha1
+kind: BaselineAdminNetworkPolicy
+metadata:
+  name: default
+spec:
+  subject:
+    namespaces:
+      matchLabels:
+          conformance-house: gryffindor
+  ingress:
+  - name: "deny-all-ingress-from-slytherin"
+    action: "Deny"
+    from:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            conformance-house: slytherin
+  egress:
+  - name: "deny-all-egress-from-slytherin"
+    action: "Deny"
+    to:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            conformance-house: slytherin


### PR DESCRIPTION
Sample run:
```
    --- PASS: TestConformance/AdminNetworkPolicyIntegration (26.16s)                                                                                                         
        --- PASS: TestConformance/AdminNetworkPolicyIntegration/Should_Deny_traffic_from_slytherin_to_gryffindor_respecting_ANP (6.31s)                                      
        --- PASS: TestConformance/AdminNetworkPolicyIntegration/Should_Deny_traffic_to_slytherin_from_gryffindor_respecting_ANP (6.32s)
        --- PASS: TestConformance/AdminNetworkPolicyIntegration/Should_support_a_'pass-ingress'_policy_for_ANP_and_respect_the_match_for_network_policy (0.46s)
        --- PASS: TestConformance/AdminNetworkPolicyIntegration/Should_support_a_'pass-egress'_policy_for_ANP_and_respect_the_match_for_network_policy (0.30s)
        --- PASS: TestConformance/AdminNetworkPolicyIntegration/Should_support_a_'pass-ingress'_policy_for_ANP_and_respect_the_match_for_baseline_admin_network_policy (6.38s)
        --- PASS: TestConformance/AdminNetworkPolicyIntegration/Should_support_a_'pass-egress'_policy_for_ANP_and_respect_the_match_for_baseline_admin_network_policy (6.35s)
PASS
```
Logic: Add ANP (deny), NP (allow) and BANP (deny) - Start with ANP Deny, change the action to Pass, ensure traffic now matches the allow NP, delete the NP and ensure traffic now matches the Deny BANP.
