### PR TITLE
Print status as part of the printer columns

### DIFF
--- a/apis/v1alpha1/adminnetworkpolicy_types.go
+++ b/apis/v1alpha1/adminnetworkpolicy_types.go
@@ -30,6 +30,10 @@ import (
 // +kubebuilder:resource:shortName=anp,scope=Cluster
 // +kubebuilder:printcolumn:name="Priority",type=string,JSONPath=".spec.priority"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Condition",type=string,JSONPath=".status.conditions[*].type"
+// +kubebuilder:printcolumn:name="Status",type=string,JSONPath=".status.conditions[*].status"
+// +kubebuilder:printcolumn:name="Reason",type=string,JSONPath=".status.conditions[*].reason"
+// +kubebuilder:printcolumn:name="Message",type=string,JSONPath=".status.conditions[*].message"
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // AdminNetworkPolicy is  a cluster level resource that is part of the
 // AdminNetworkPolicy API.

--- a/apis/v1alpha1/baselineadminnetworkpolicy_types.go
+++ b/apis/v1alpha1/baselineadminnetworkpolicy_types.go
@@ -25,6 +25,10 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=banp,scope=Cluster
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Condition",type=string,JSONPath=".status.conditions[*].type"
+// +kubebuilder:printcolumn:name="Status",type=string,JSONPath=".status.conditions[*].status"
+// +kubebuilder:printcolumn:name="Reason",type=string,JSONPath=".status.conditions[*].reason"
+// +kubebuilder:printcolumn:name="Message",type=string,JSONPath=".status.conditions[*].message"
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:validation:XValidation:rule="self.metadata.name == 'default'",message="Only one baseline admin network policy with metadata.name=\"default\" can be created in the cluster"
 // BaselineAdminNetworkPolicy is a cluster level resource that is part of the

--- a/config/crd/policy.networking.k8s.io_adminnetworkpolicies.yaml
+++ b/config/crd/policy.networking.k8s.io_adminnetworkpolicies.yaml
@@ -24,6 +24,18 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - jsonPath: .status.conditions[*].type
+      name: Condition
+      type: string
+    - jsonPath: .status.conditions[*].status
+      name: Status
+      type: string
+    - jsonPath: .status.conditions[*].reason
+      name: Reason
+      type: string
+    - jsonPath: .status.conditions[*].message
+      name: Message
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/crd/policy.networking.k8s.io_baselineadminnetworkpolicies.yaml
+++ b/config/crd/policy.networking.k8s.io_baselineadminnetworkpolicies.yaml
@@ -21,6 +21,18 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - jsonPath: .status.conditions[*].type
+      name: Condition
+      type: string
+    - jsonPath: .status.conditions[*].status
+      name: Status
+      type: string
+    - jsonPath: .status.conditions[*].reason
+      name: Reason
+      type: string
+    - jsonPath: .status.conditions[*].message
+      name: Message
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
This commit adds support for printing the status
of ANP and BANP when doing `kubectl get` so that
implementations can let users know the status
of these resources - note that the status field
is not standardtized and is upto the plugins to
implement them according to their logic.

Sample output:
```
$ oc get anp pass-example 
NAME           PRIORITY   AGE   CONDITION                 STATUS   REASON
pass-example   10         13m   AdminNetworkPolicyReady   True     SetupSucceeded
```