### PR TITLE
Change conformance test ready condition

### DIFF
--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -123,7 +123,13 @@ func (suite *ConformanceTestSuite) Setup(t *testing.T) {
 			"network-policy-conformance-hufflepuff",
 			"network-policy-conformance-ravenclaw",
 		}
-		kubernetes.NamespacesMustBeReady(t, suite.Client, suite.TimeoutConfig, namespaces)
+		statefulSets := []string{
+			"harry-potter",
+			"draco-malfoy",
+			"cedric-diggory",
+			"luna-lovegood",
+		}
+		kubernetes.NamespacesMustBeReady(t, suite.Client, suite.TimeoutConfig, namespaces, statefulSets)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -6,13 +6,14 @@ require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.3.0
 	github.com/stretchr/testify v1.8.1
 	k8s.io/api v0.26.1
+	k8s.io/apiextensions-apiserver v0.26.1
 	k8s.io/apimachinery v0.26.1
 	k8s.io/client-go v0.26.1
 	k8s.io/code-generator v0.26.1
-	k8s.io/klog v0.2.0
 	k8s.io/kubernetes v1.26.0
 	sigs.k8s.io/controller-runtime v0.14.6
 	sigs.k8s.io/controller-tools v0.11.1
+	sigs.k8s.io/yaml v1.3.0
 )
 
 require (
@@ -91,11 +92,11 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apiextensions-apiserver v0.26.1 // indirect
 	k8s.io/apiserver v0.26.1 // indirect
 	k8s.io/component-base v0.26.1 // indirect
 	k8s.io/component-helpers v0.26.0 // indirect
 	k8s.io/gengo v0.0.0-20220902162205-c0856e24416d // indirect
+	k8s.io/klog v0.2.0 // indirect
 	k8s.io/klog/v2 v2.90.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 // indirect
 	k8s.io/kubectl v0.26.0 // indirect
@@ -104,5 +105,4 @@ require (
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.35 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
-	sigs.k8s.io/yaml v1.3.0 // indirect
 )


### PR DESCRIPTION
In the conformance test suite, currently pod ready status is used to determine whether tests should be commenced. However, in some testbeds, listing pods in a namespace when the a StatefulSet has just been created will return empty list, thus bypassing the pod ready test, causing subsequent tests to fail:

```
=== RUN   TestNetworkPolicyV2Conformance
    adminnetworkpolicy_test.go:43: Configuring environment for network policy API conformance tests
    adminnetworkpolicy_test.go:60: Starting the network policy conformance test suite
    suite.go:116: Test Setup: Applying base manifests
    apply.go:124: Creating network-policy-conformance-gryffindor Namespace
    apply.go:124: Creating network-policy-conformance-slytherin Namespace
    apply.go:124: Creating network-policy-conformance-hufflepuff Namespace
    apply.go:124: Creating network-policy-conformance-ravenclaw Namespace
    apply.go:124: Creating harry-potter StatefulSet
    apply.go:124: Creating draco-malfoy StatefulSet
    apply.go:124: Creating cedric-diggory StatefulSet
    apply.go:124: Creating luna-lovegood StatefulSet
    suite.go:119: Test Setup: Ensuring Namespaces and Pods from base manifests are ready
    helper.go:95: Namespaces and Pods in network-policy-conformance-gryffindor, network-policy-conformance-slytherin, network-policy-conformance-hufflepuff, network-policy-conformance-ravenclaw namespaces ready
=== RUN   TestNetworkPolicyV2Conformance/AdminNetworkPolicyEgressSCTP
    suite.go:172: Applying base/admin_network_policy/core-egress-sctp-rules.yaml
    apply.go:124: Creating egress-sctp AdminNetworkPolicy
=== RUN   TestNetworkPolicyV2Conformance/AdminNetworkPolicyEgressSCTP/Should_support_an_'allow-egress'_policy_for_SCTP_protocol;_ensure_rule_ordering_is_respected
  Jul 17 22:03:18.000: INFO: Running '/usr/local/bin/kubectl --namespace=network-policy-conformance-ravenclaw exec luna-lovegood-0 -- /agnhost connect --timeout=3s --protocol=sctp :9003'
  Jul 17 22:03:18.271: INFO: rc: 1
  Jul 17 22:03:18.271: INFO: FAILED Command was [/agnhost connect --timeout=3s --protocol=sctp :9003]
  Jul 17 22:03:18.271: INFO: FAILED Response was , expected connection to succeed from luna-lovegood-0 to , but instead it miserably failed: error running /usr/local/bin/kubectl --namespace=network-policy-conformance-ravenclaw exec luna-lovegood-0 -- /agnhost connect --timeout=3s --protocol=sctp :9003:
```
In the above log, the IP of pod `luna-lovegood-0` is not retrieved so the connection command ` [/agnhost connect --timeout=3s --protocol=sctp :9003]` undoubtedly failed.
This PR changes the readiness check to use the StatefulSet replica count in its status.