### PR TITLE
setup for v0.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Table of Contents
 
 - [v0.1.0](#v010)
+- [v0.1.1](#v011)
 
 # v0.1.0
 
@@ -13,5 +14,25 @@ main resources geared towards cluster admins:
 
 - AdminNetworkPolicy
 - BaselineAdminNetworkPolicy
+
+Please check out the [network-policy-api website](https://network-policy-api.sigs.k8s.io/) for more information.
+
+# v0.1.1
+
+API Version: v1alpha1
+
+This is a patch release of the network-policy-api. It includes two
+main resources geared towards cluster admins:
+
+- AdminNetworkPolicy
+- BaselineAdminNetworkPolicy
+
+Additionally it includes many conformance test updates and fixes:
+
+- Ingress/Egress Traffic conformance for TCP/UDP/SCTP
+- Movement of base testing yamls
+- Variable renaming and comment improvements
+- Increased default timeout
+- Removal of K8s.io/kubernetes dependency
 
 Please check out the [network-policy-api website](https://network-policy-api.sigs.k8s.io/) for more information.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -52,7 +52,9 @@ For a **PATCH** release:
   Github's [release][release] page.
 - Run the `make build-install-yaml` command which will generate install files in the `release/` directory.
   Attach these files to the Github release.
-- Update the `README.md` and `site-src/guides/index.md` files to point links and examples to the new release.
+- Update the website files to point links and examples to the new release (simply `grep` for previous version).
+- Write a changelog for the new release in the [changelog readme](./CHANGELOG.md).
+- Make the new-release from the [releases page](https://github.com/kubernetes-sigs/network-policy-api/releases) with the new changelog and attach the `install.yaml`.
 
 For a **MAJOR** or **MINOR** release:
 
@@ -64,7 +66,9 @@ For a **MAJOR** or **MINOR** release:
   Github's [release][release] page.
 - Run the `make build-install-yaml` command which will generate install files in the `release/` directory.
   Attach these files to the Github release.
-- Update the `README.md` and `site-src/guides/index.md` files to point links and examples to the new release.
+- Update the website files to point links and examples to the new release (simply `grep` for previous version).
+- Write a changelog for the new release in the [changelog readme](./CHANGELOG.md).
+- Make the new-release from the [releases page](https://github.com/kubernetes-sigs/network-policy-api/releases) with the new changelog and attach the `install.yaml`.
 
 For an **RC** release:
 

--- a/config/crd/policy.networking.k8s.io_adminnetworkpolicies.yaml
+++ b/config/crd/policy.networking.k8s.io_adminnetworkpolicies.yaml
@@ -2,8 +2,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/network-policy-api/pull/106
-    policy.networking.k8s.io/bundle-version: v0.1.0
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/network-policy-api/pull/135
+    policy.networking.k8s.io/bundle-version: v0.1.1
   creationTimestamp: null
   name: adminnetworkpolicies.policy.networking.k8s.io
 spec:

--- a/config/crd/policy.networking.k8s.io_baselineadminnetworkpolicies.yaml
+++ b/config/crd/policy.networking.k8s.io_baselineadminnetworkpolicies.yaml
@@ -2,8 +2,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/network-policy-api/pull/106
-    policy.networking.k8s.io/bundle-version: v0.1.0
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/network-policy-api/pull/135
+    policy.networking.k8s.io/bundle-version: v0.1.1
   creationTimestamp: null
   name: baselineadminnetworkpolicies.policy.networking.k8s.io
 spec:

--- a/pkg/generator/main.go
+++ b/pkg/generator/main.go
@@ -29,8 +29,8 @@ const (
 	bundleVersionAnnotation = "policy.networking.k8s.io/bundle-version"
 
 	// These values must be updated during the release process
-	bundleVersion = "v0.1.0"
-	approvalLink  = "https://github.com/kubernetes-sigs/network-policy-api/pull/106"
+	bundleVersion = "v0.1.1"
+	approvalLink  = "https://github.com/kubernetes-sigs/network-policy-api/pull/135"
 )
 
 // This generation code is largely copied from


### PR DESCRIPTION
We're still not doing this release process 100% correct and should instead be opening a PR against the v0.1.0 branch reviewing there before merging this to update the changelog and cut the release

However, for now we're just shipping conformance fixes so that should be alright. 

Please see https://github.com/kubernetes-sigs/network-policy-api/compare/v0.1.0...v0.1.1 for all the changes since v0.1.0