### PR TITLE
Pod selector conformance tests

### DIFF
--- a/conformance/base/admin_network_policy/core-egress-sctp-rules.yaml
+++ b/conformance/base/admin_network_policy/core-egress-sctp-rules.yaml
@@ -70,3 +70,55 @@ spec:
         namespaceSelector:
           matchLabels:
             kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
+  - name: "deny-to-professor-quirrell-everything"
+    action: "Deny"
+    to:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-quirrell-0
+  - name: "allow-to-professor-dumbledore"
+    action: "Allow"
+    to:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-dumbledore-0
+    ports:
+      - portNumber:
+          protocol: SCTP
+          port: 9003
+  - name: "allow-to-professor-dumbledore"
+    action: "Allow"
+    to:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-dumbledore-0
+    ports:
+      - portNumber:
+          protocol: SCTP
+          port: 9005
+  - name: "deny-to-dumbledore-everything-else"
+    action: "Deny"
+    to:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-dumbledore-0

--- a/conformance/base/admin_network_policy/core-egress-tcp-rules.yaml
+++ b/conformance/base/admin_network_policy/core-egress-tcp-rules.yaml
@@ -70,3 +70,44 @@ spec:
         namespaceSelector:
           matchLabels:
             kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
+  - name: "deny-to-professor-quirrell-at-port-8080"
+    action: "Deny"
+    to:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-quirrell-0
+    ports:
+      - portNumber:
+          protocol: TCP
+          port: 8080
+  - name: "allow-to-professor-dumbledore-at-port-8080"
+    action: "Allow"
+    to:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-dumbledore-0
+    ports:
+      - portNumber:
+          protocol: TCP
+          port: 8080
+  - name: "deny-to-dumbledore-everything-else"
+    action: "Deny"
+    to:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-dumbledore-0

--- a/conformance/base/admin_network_policy/core-egress-udp-rules.yaml
+++ b/conformance/base/admin_network_policy/core-egress-udp-rules.yaml
@@ -70,3 +70,74 @@ spec:
         namespaceSelector:
           matchLabels:
             kubernetes.io/metadata.name: network-policy-conformance-gryffindor
+  - name: "deny-to-professor-quirrell-at-port-53"
+    action: "Deny"
+    to:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-quirrell-0
+    ports:
+      - portNumber:
+          protocol: UDP
+          port: 53
+  - name: "deny-to-professor-quirrell-at-port-53"
+    action: "Deny"
+    to:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-quirrell-0
+    ports:
+      - portNumber:
+          protocol: UDP
+          port: 5353
+  - name: "allow-to-professor-dumbledore-at-port-53"
+    action: "Allow"
+    to:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-dumbledore-0
+    ports:
+      - portNumber:
+          protocol: UDP
+          port: 53
+  - name: "allow-to-professor-dumbledore-at-port-5353"
+    action: "Allow"
+    to:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-dumbledore-0
+    ports:
+      - portNumber:
+          protocol: UDP
+          port: 5353
+  - name: "deny-to-dumbledore-everything-else"
+    action: "Deny"
+    to:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-dumbledore-0

--- a/conformance/base/admin_network_policy/core-gress-rules-combined.yaml
+++ b/conformance/base/admin_network_policy/core-gress-rules-combined.yaml
@@ -88,6 +88,59 @@ spec:
         namespaceSelector:
           matchLabels:
             kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
+  - name: "allow-to-dumbledore-at-tcp-udp-sctp"
+    action: "Allow"
+    to:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-dumbledore-0
+    ports:
+      - portNumber:
+          protocol: TCP
+          port: 8080
+      - portNumber:
+          protocol: UDP
+          port: 5353
+      - portNumber:
+          protocol: SCTP
+          port: 9003
+  - name: "deny-to-dumbledore-everything-else"
+    action: "Deny"
+    to:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-dumbledore-0
+  - name: "deny-to-quirrell-at-tcp-udp-sctp"
+    action: "Deny"
+    to:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-quirrell-0
+    ports:
+      - portNumber:
+          protocol: TCP
+          port: 8080
+      - portNumber:
+          protocol: UDP
+          port: 5353
+      - portNumber:
+          protocol: SCTP
+          port: 9003
   ingress:
   - name: "allow-from-ravenclaw-everything"
     action: "Allow"
@@ -168,3 +221,56 @@ spec:
         namespaceSelector:
           matchLabels:
             kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
+  - name: "allow-from-dumbledore-at-tcp-udp-sctp"
+    action: "Allow"
+    from:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-dumbledore-0
+    ports:
+      - portNumber:
+          protocol: TCP
+          port: 8080
+      - portNumber:
+          protocol: UDP
+          port: 5353
+      - portNumber:
+          protocol: SCTP
+          port: 9003
+  - name: "deny-from-dumbledore-everything-else"
+    action: "Deny"
+    from:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-dumbledore-0
+  - name: "deny-from-quirrell-at-tcp-udp-sctp"
+    action: "Deny"
+    from:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-quirrell-0
+    ports:
+      - portNumber:
+          protocol: TCP
+          port: 8080
+      - portNumber:
+          protocol: UDP
+          port: 5353
+      - portNumber:
+          protocol: SCTP
+          port: 9003

--- a/conformance/base/admin_network_policy/core-ingress-sctp-rules.yaml
+++ b/conformance/base/admin_network_policy/core-ingress-sctp-rules.yaml
@@ -70,3 +70,44 @@ spec:
         namespaceSelector:
           matchLabels:
             kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
+  - name: "deny-from-professor-quirrell-at-ports-9003"
+    action: "Deny"
+    from:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-quirrell-0
+    ports:
+      - portNumber:
+          protocol: SCTP
+          port: 9003
+  - name: "allow-from-professor-dumbledore-at-ports-9003"
+    action: "Allow"
+    from:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-dumbledore-0
+    ports:
+      - portNumber:
+          protocol: SCTP
+          port: 9003
+  - name: "deny-from-dumbledore-everything-else"
+    action: "Deny"
+    from:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-dumbledore-0

--- a/conformance/base/admin_network_policy/core-ingress-tcp-rules.yaml
+++ b/conformance/base/admin_network_policy/core-ingress-tcp-rules.yaml
@@ -70,3 +70,44 @@ spec:
         namespaceSelector:
           matchLabels:
             kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
+  - name: "deny-from-professor-quirrell-at-port-8080"
+    action: "Deny"
+    from:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-quirrell-0
+    ports:
+      - portNumber:
+          protocol: TCP
+          port: 8080
+  - name: "allow-from-professor-dumbledore-at-port-8080"
+    action: "Allow"
+    from:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-dumbledore-0
+    ports:
+      - portNumber:
+          protocol: TCP
+          port: 8080
+  - name: "deny-from-dumbledore-everything-else"
+    action: "Deny"
+    from:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-dumbledore-0

--- a/conformance/base/admin_network_policy/core-ingress-udp-rules.yaml
+++ b/conformance/base/admin_network_policy/core-ingress-udp-rules.yaml
@@ -70,3 +70,85 @@ spec:
         namespaceSelector:
           matchLabels:
             kubernetes.io/metadata.name: network-policy-conformance-gryffindor
+  - name: "deny-from-professor-quirrell-port-53"
+    action: "Deny"
+    from:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-quirrell-0
+    ports:
+      - portNumber:
+          protocol: UDP
+          port: 53
+  - name: "deny-from-professor-quirrell-port-5353"
+    action: "Deny"
+    from:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-quirrell-1
+    ports:
+      - portNumber:
+          protocol: UDP
+          port: 5353
+  - name: "allow-from-professor-dumbledore-at-ports-53"
+    action: "Allow"
+    from:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-dumbledore-0
+    ports:
+      - portNumber:
+          protocol: UDP
+          port: 53
+  - name: "allow-from-professor-dumbledore-at-ports-5353"
+    action: "Allow"
+    from:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-dumbledore-1
+    ports:
+      - portNumber:
+          protocol: UDP
+          port: 5353
+  - name: "deny-from-dumbledore-everything-else"
+    action: "Deny"
+    from:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-dumbledore-0
+  - name: "deny-from-dumbledore-everything-else"
+    action: "Deny"
+    from:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-dumbledore-1

--- a/conformance/base/baseline_admin_network_policy/core-egress-sctp-rules.yaml
+++ b/conformance/base/baseline_admin_network_policy/core-egress-sctp-rules.yaml
@@ -51,3 +51,44 @@ spec:
         namespaceSelector:
           matchLabels:
             kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
+  - name: "deny-to-professor-quirrell-at-port-9003"
+    action: "Deny"
+    to:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-quirrell-0
+    ports:
+      - portNumber:
+          protocol: SCTP
+          port: 9003
+  - name: "allow-to-professor-dumbledore"
+    action: "Allow"
+    to:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-dumbledore-0
+    ports:
+      - portNumber:
+          protocol: SCTP
+          port: 9003
+  - name: "deny-to-dumbledore-everything-else"
+    action: "Deny"
+    to:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-dumbledore-0

--- a/conformance/base/baseline_admin_network_policy/core-egress-tcp-rules.yaml
+++ b/conformance/base/baseline_admin_network_policy/core-egress-tcp-rules.yaml
@@ -51,3 +51,33 @@ spec:
         namespaceSelector:
           matchLabels:
             kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
+  - name: "deny-to-professor-quirrell"
+    action: "Deny"
+    to:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-quirrell-0
+    ports:
+      - portNumber:
+          protocol: TCP
+          port: 80
+  - name: "allow-to-professor-dumbledore"
+    action: "Allow"
+    to:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-dumbledore-0
+    ports:
+      - portNumber:
+          protocol: TCP
+          port: 80

--- a/conformance/base/baseline_admin_network_policy/core-egress-udp-rules.yaml
+++ b/conformance/base/baseline_admin_network_policy/core-egress-udp-rules.yaml
@@ -51,3 +51,33 @@ spec:
         namespaceSelector:
           matchLabels:
             kubernetes.io/metadata.name: network-policy-conformance-gryffindor
+  - name: "deny-to-professor-quirrell"
+    action: "Deny"
+    to:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-quirrell-0
+    ports:
+      - portNumber:
+          protocol: UDP 
+          port: 53
+  - name: "allow-to-professor-dumbledore"
+    action: "Allow"
+    to:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-dumbledore-0
+    ports:
+      - portNumber:
+          protocol: UDP 
+          port: 53

--- a/conformance/base/baseline_admin_network_policy/core-gress-rules-combined.yaml
+++ b/conformance/base/baseline_admin_network_policy/core-gress-rules-combined.yaml
@@ -63,6 +63,48 @@ spec:
         namespaceSelector:
           matchLabels:
             kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
+  - name: "allow-from-dumbledore-at-tcp-udp-sctp"
+    action: "Allow"
+    to:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-dumbledore-0
+    ports:
+      - portNumber:
+          protocol: TCP
+          port: 8080
+      - portNumber:
+          protocol: UDP
+          port: 5353
+      - portNumber:
+          protocol: SCTP
+          port: 9003
+  - name: "deny-to-quirrell-at-tcp-udp-sctp"
+    action: "Deny"
+    to:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-quirrell-0
+    ports:
+      - portNumber:
+          protocol: TCP
+          port: 8080
+      - portNumber:
+          protocol: UDP
+          port: 5353
+      - portNumber:
+          protocol: SCTP
+          port: 9003
   ingress:
   - name: "allow-from-ravenclaw-everything"
     action: "Allow"

--- a/conformance/base/baseline_admin_network_policy/core-ingress-sctp-rules.yaml
+++ b/conformance/base/baseline_admin_network_policy/core-ingress-sctp-rules.yaml
@@ -51,3 +51,44 @@ spec:
         namespaceSelector:
           matchLabels:
             kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
+  - name: "deny-from-professor-quirrell-at-port-8080"
+    action: "Deny"
+    from:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-quirrell-0
+    ports:
+      - portNumber:
+          protocol: SCTP 
+          port: 9003 
+  - name: "allow-from-professor-dumbledore-at-port-8080"
+    action: "Allow"
+    from:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-dumbledore-0
+    ports:
+      - portNumber:
+          protocol: SCTP
+          port: 9003 
+  - name: "deny-from-dumbledore-everything-else"
+    action: "Deny"
+    from:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-dumbledore-0

--- a/conformance/base/baseline_admin_network_policy/core-ingress-tcp-rules.yaml
+++ b/conformance/base/baseline_admin_network_policy/core-ingress-tcp-rules.yaml
@@ -51,3 +51,33 @@ spec:
         namespaceSelector:
           matchLabels:
             kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
+  - name: "deny-professor-quirrell-at-80"
+    action: "Deny"
+    from:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-quirrell-0
+    ports:
+      - portNumber:
+          protocol: TCP
+          port: 80
+  - name: "allow-professor-dumbledore-at-80"
+    action: "Allow"
+    from:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-dumbledore-0
+    ports:
+      - portNumber:
+          protocol: TCP
+          port: 80

--- a/conformance/base/baseline_admin_network_policy/core-ingress-udp-rules.yaml
+++ b/conformance/base/baseline_admin_network_policy/core-ingress-udp-rules.yaml
@@ -51,3 +51,33 @@ spec:
         namespaceSelector:
           matchLabels:
             kubernetes.io/metadata.name: network-policy-conformance-gryffindor
+  - name: "deny-from-professor-quirrell-at-53"
+    action: "Deny"
+    from:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-quirrell-0
+    ports:
+      - portNumber:
+          protocol: UDP 
+          port: 53
+  - name: "allow-from-professor-dumbledore-at-80"
+    action: "Allow"
+    from:
+    - pods:
+        namespaces:
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network-policy-conformance-hogwarts-staff
+        podSelector:
+          matchLabels:
+            statefulset.kubernetes.io/pod-name: professor-dumbledore-0
+    ports:
+      - portNumber:
+          protocol: UDP 
+          port: 53

--- a/conformance/base/manifests.yaml
+++ b/conformance/base/manifests.yaml
@@ -26,6 +26,13 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  name: network-policy-conformance-hogwarts-staff
+  labels:
+    conformance-house: hogwarts-staff
+---
+apiVersion: v1
+kind: Namespace
+metadata:
   name: network-policy-conformance-ravenclaw
   labels:
     conformance-house: ravenclaw
@@ -76,6 +83,92 @@ spec:
           - name: SERVE_SCTP_PORT_9003
             value: "foo"
         - name: harry-potter-9005
+          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+          command: ["/bin/bash", "-c", "/agnhost porter"]
+          env:
+          - name: SERVE_SCTP_PORT_9005
+            value: "foo"
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: professor-dumbledore
+  namespace: network-policy-conformance-hogwarts-staff
+spec:
+  selector:
+    matchLabels:
+      conformance-house: hogwarts-staff
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        conformance-house: hogwarts-staff
+    spec:
+      containers:
+        - name: professor-dumbledore-client
+          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+        - name: professor-dumbledore-80
+          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+          command: ["/bin/bash", "-c", "/agnhost serve-hostname --tcp --http=false --port 80"]
+        - name: professor-dumbledore-8080
+          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+          command: ["/bin/bash", "-c", "/agnhost serve-hostname --tcp --http=false --port 8080"]
+        - name: professor-dumbledore-5353
+          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+          command: ["/bin/bash", "-c", "/agnhost serve-hostname --udp --http=false --port 5353"]
+        - name: professor-dumbledore-53
+          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+          command: ["/bin/bash", "-c", "/agnhost serve-hostname --udp --http=false --port 53"]
+        - name: professor-dumbledore-9003
+          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+          command: ["/bin/bash", "-c", "/agnhost porter"]
+          env:
+          - name: SERVE_SCTP_PORT_9003
+            value: "foo"
+        - name: professor-dumbledore-9005
+          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+          command: ["/bin/bash", "-c", "/agnhost porter"]
+          env:
+          - name: SERVE_SCTP_PORT_9005
+            value: "foo"
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: professor-quirrell
+  namespace: network-policy-conformance-hogwarts-staff
+spec:
+  selector:
+    matchLabels:
+      conformance-house: hogwarts-staff
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        conformance-house: hogwarts-staff
+    spec:
+      containers:
+        - name: professor-quirrell-client
+          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+        - name: professor-quirrell-80
+          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+          command: ["/bin/bash", "-c", "/agnhost serve-hostname --tcp --http=false --port 80"]
+        - name: professor-quirrell-8080
+          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+          command: ["/bin/bash", "-c", "/agnhost serve-hostname --tcp --http=false --port 8080"]
+        - name: professor-quirrell-5353
+          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+          command: ["/bin/bash", "-c", "/agnhost serve-hostname --udp --http=false --port 5353"]
+        - name: professor-quirrell-53
+          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+          command: ["/bin/bash", "-c", "/agnhost serve-hostname --udp --http=false --port 53"]
+        - name: professor-quirrell-9003
+          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+          command: ["/bin/bash", "-c", "/agnhost porter"]
+          env:
+          - name: SERVE_SCTP_PORT_9003
+            value: "foo"
+        - name: professor-quirrell-9005
           image: registry.k8s.io/e2e-test-images/agnhost:2.43
           command: ["/bin/bash", "-c", "/agnhost porter"]
           env:

--- a/conformance/tests/baseline-admin-network-policy-core-egress-sctp-rules.go
+++ b/conformance/tests/baseline-admin-network-policy-core-egress-sctp-rules.go
@@ -33,7 +33,53 @@ import (
 func init() {
 	ConformanceTests = append(ConformanceTests,
 		BaselineAdminNetworkPolicyEgressSCTP,
+		BaselineAdminNetworkPolicyEgressPodSelectorSCTP,
 	)
+}
+
+var BaselineAdminNetworkPolicyEgressPodSelectorSCTP = suite.ConformanceTest{
+	ShortName:   "BaselineAdminNetworkPolicyEgressPodSelectorSCTP",
+	Description: "Tests support for egress traffic (SCTP protocol) at specific pods using baseline admin network policy API based on a server and client model",
+	Features: []suite.SupportedFeature{
+		suite.SupportBaselineAdminNetworkPolicy,
+	},
+	Manifests: []string{"base/baseline_admin_network_policy/core-egress-sctp-rules.yaml"},
+	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+
+		t.Run("Should support an 'allow-egress' policy for SCTP protocol at the specified pod", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+
+			serverPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-hogwarts-staff",
+				Name:      "professor-dumbledore-0",
+			}, serverPod)
+			require.NoErrorf(t, err, "unable to fetch the server pod")
+
+			// ensure egress is ALLOWED to Professor Dumbledore from ravenclaw
+			success := kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-ravenclaw", "luna-lovegood-0", "sctp",
+				serverPod.Status.PodIP, int32(9003), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+		})
+
+		t.Run("Should support a 'deny-egress' policy for SCTP protocol at the specified pod", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+
+			serverPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-hogwarts-staff",
+				Name:      "professor-quirrell-0",
+			}, serverPod)
+			require.NoErrorf(t, err, "unable to fetch the server pod")
+
+			// ensure egress is DENIED to professor quirrell from ravenclaw
+			success := kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-ravenclaw", "luna-lovegood-0", "sctp",
+				serverPod.Status.PodIP, int32(9003), s.TimeoutConfig.RequestTimeout, false)
+			assert.Equal(t, true, success)
+		})
+	},
 }
 
 var BaselineAdminNetworkPolicyEgressSCTP = suite.ConformanceTest{

--- a/conformance/tests/baseline-admin-network-policy-core-ingress-udp-rules.go
+++ b/conformance/tests/baseline-admin-network-policy-core-ingress-udp-rules.go
@@ -33,7 +33,52 @@ import (
 func init() {
 	ConformanceTests = append(ConformanceTests,
 		BaselineAdminNetworkPolicyIngressUDP,
+		BaselineAdminNetworkPolicyIngressPodSelectorUDP,
 	)
+}
+
+var BaselineAdminNetworkPolicyIngressPodSelectorUDP = suite.ConformanceTest{
+	ShortName:   "BaselineAdminNetworkPolicyIngressPodSelectorUDP",
+	Description: "Tests support for ingress traffic (UDP protocol) at the specific targeted pod using baseline admin network policy API based on a server and client model",
+	Features: []suite.SupportedFeature{
+		suite.SupportBaselineAdminNetworkPolicy,
+	},
+	Manifests: []string{"base/baseline_admin_network_policy/core-ingress-udp-rules.yaml"},
+	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+		t.Run("Should support an 'allow-ingress' policy for UDP protocol at the specified pod", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `default` BANP
+			// luna-lovegood-0 is our server pod in ravenclaw namespace
+			serverPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-hufflepuff",
+				Name:      "cedric-diggory-0",
+			}, serverPod)
+			require.NoErrorf(t, err, "unable to fetch the server pod")
+
+			success := kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-hogwarts-staff", "professor-dumbledore-0", "udp",
+				serverPod.Status.PodIP, int32(53), s.TimeoutConfig.RequestTimeout, true)
+			assert.Equal(t, true, success)
+		})
+
+		t.Run("Should support a 'deny-ingress' policy for UDP protocol at the specified pod", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+			defer cancel()
+			// This test uses `default` BANP
+			// luna-lovegood-0 is our server pod in ravenclaw namespace
+			serverPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-hufflepuff",
+				Name:      "cedric-diggory-0",
+			}, serverPod)
+			require.NoErrorf(t, err, "unable to fetch the server pod")
+
+			success := kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-hogwarts-staff", "professor-quirrell-0", "udp",
+				serverPod.Status.PodIP, int32(53), s.TimeoutConfig.RequestTimeout, false)
+			assert.Equal(t, true, success)
+		})
+	},
 }
 
 var BaselineAdminNetworkPolicyIngressUDP = suite.ConformanceTest{


### PR DESCRIPTION
Add pod selector conformance tests. See https://github.com/kubernetes-sigs/network-policy-api/issues/104 for details


- [x] ANP TCP
  - ~~Ingress~~
  - ~~Egress~~
- [x] ANP UDP
  - ~~Ingress~~
  - ~~Egress~~
- [x] ANP SCTP
  - ~~Ingress~~
  - ~~Egress~~
- [x] BANP TCP
  - ~~Ingress~~
  - ~~Egress~~
- [x] BANP UDP
  - ~~Ingress~~
  - ~~Egress~~
- [x] BANP SCTP
  - ~~Ingress~~
  - ~~Egress~~