### PR TITLE
NPEP: Iron out Cluster Egress Support API Design

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,11 +62,11 @@ nav:
     - Enhancement Proposals:
       - Overview: enhancements.md
       - Template: npeps/npep-95.md
-      - Provisional: 
-        - npeps/npep-126-egress-traffic-control.md
+      - Provisional:
         - npeps/npep-122.md
       - Implementable:
         - npeps/npep-137-conformance-profiles.md
+        - npeps/npep-126-egress-traffic-control.md
         # - Experimental:
         # - Standard:
         # - Declined:


### PR DESCRIPTION
See POC: https://github.com/kubernetes-sigs/network-policy-api/pull/143

A few things were discussed in the sig-network-policy-api meeting that happened on 10th October 2023:

1. Should we diverge on our ingress and egress peer types - since we are adding only egress support initially and FQDN is also an egress peer thing? As per apiserver team recommendations that seems to be the best way forward? CONSENSUS: Yes let's have `AdminNetworkPolicyPeerIngress` and `AdminNetworkPolicyPeerEgress` types -> this will be commit1 of POC PR: https://github.com/kubernetes-sigs/network-policy-api/pull/143.
2. Should we openly callout that `Namespace` and `Pods` peer types do NOT account for host-networked pods ? CONSENSUS: Yes, makes sense; let's do that. Opened https://github.com/kubernetes-sigs/network-policy-api/pull/156
3. Should we have CIDRs and FQDNs inside the main API for ANP and BANP OR should we go with `ExternalNetworks` CRD like mentioned in the NPEP? Both have advantages and disadvantages and during the meeting no-one had strong preferences and nobody opposed either OR which is good. But we wanted to check back with @rahulkjoshi on what would make sense for FQDN egress peers. So for now going ahead with whatever is present in the NPEP and then we can narrow in on that.
4. What about node2pod healthchecks that NetworkPolicy API allows implicitly: https://kubernetes.io/docs/concepts/services-networking/network-policies/ (`When a pod is isolated for ingress, the only allowed connections into the pod are those from the pod's node`)? For ANP we don't want that, we want admins to be able to explicitly specify that relation. This can be the ability to express `isSameNode` relation for a pod dynamically in addition to giving out `NodeSelectors` but this is an ingress traffic user story. CONSENSUS: Since we will split the peers as ingress/egress as per (1), this API design detail can be covered as part of ingress NPEP. As of now we don't have user stories that ask of this for egress traffic (I want pods to be able to talk to only my node).
5. What about "internalDestinations?" -> NetPol defined "ipBlock" as a type of peer which can have podCIDRs/nodeCIDRs whatever in it, in ANP we are trying to explicitly define a peer as "outside the cluster" sort of like egressIPs where intra cluster traffic is not considered as egress. However some implementations cannot distinguish between internal and external... so how strong should this definition of "northbound destinations" be?