### PR TITLE
Callout namespaces/pods peers do not include host-net pods

### DIFF
--- a/apis/v1alpha1/shared_types.go
+++ b/apis/v1alpha1/shared_types.go
@@ -127,14 +127,16 @@ type PortRange struct {
 // +kubebuilder:validation:MaxProperties=1
 // +kubebuilder:validation:MinProperties=1
 type AdminNetworkPolicyPeer struct {
-	// Namespaces defines a way to select a set of Namespaces.
+	// Namespaces defines a way to select all pods within a set of Namespaces.
+	// Note that host-networked pods are not included in this type of peer.
 	//
 	// Support: Core
 	//
 	// +optional
 	Namespaces *NamespacedPeer `json:"namespaces,omitempty"`
 	// Pods defines a way to select a set of pods in
-	// in a set of namespaces.
+	// in a set of namespaces. Note that host-networked pods
+	// are not included in this type of peer.
 	//
 	// Support: Core
 	//

--- a/config/crd/experimental/policy.networking.k8s.io_adminnetworkpolicies.yaml
+++ b/config/crd/experimental/policy.networking.k8s.io_adminnetworkpolicies.yaml
@@ -165,8 +165,10 @@ spec:
                         minProperties: 1
                         properties:
                           namespaces:
-                            description: "Namespaces defines a way to select a set
-                              of Namespaces. \n Support: Core"
+                            description: "Namespaces defines a way to select all pods
+                              within a set of Namespaces. Note that host-networked
+                              pods are not included in this type of peer. \n Support:
+                              Core"
                             maxProperties: 1
                             minProperties: 1
                             properties:
@@ -249,7 +251,9 @@ spec:
                             type: object
                           pods:
                             description: "Pods defines a way to select a set of pods
-                              in in a set of namespaces. \n Support: Core"
+                              in in a set of namespaces. Note that host-networked
+                              pods are not included in this type of peer. \n Support:
+                              Core"
                             properties:
                               namespaces:
                                 description: "Namespaces is used to select a set of
@@ -445,8 +449,10 @@ spec:
                         minProperties: 1
                         properties:
                           namespaces:
-                            description: "Namespaces defines a way to select a set
-                              of Namespaces. \n Support: Core"
+                            description: "Namespaces defines a way to select all pods
+                              within a set of Namespaces. Note that host-networked
+                              pods are not included in this type of peer. \n Support:
+                              Core"
                             maxProperties: 1
                             minProperties: 1
                             properties:
@@ -529,7 +535,9 @@ spec:
                             type: object
                           pods:
                             description: "Pods defines a way to select a set of pods
-                              in in a set of namespaces. \n Support: Core"
+                              in in a set of namespaces. Note that host-networked
+                              pods are not included in this type of peer. \n Support:
+                              Core"
                             properties:
                               namespaces:
                                 description: "Namespaces is used to select a set of

--- a/config/crd/experimental/policy.networking.k8s.io_baselineadminnetworkpolicies.yaml
+++ b/config/crd/experimental/policy.networking.k8s.io_baselineadminnetworkpolicies.yaml
@@ -157,8 +157,10 @@ spec:
                         minProperties: 1
                         properties:
                           namespaces:
-                            description: "Namespaces defines a way to select a set
-                              of Namespaces. \n Support: Core"
+                            description: "Namespaces defines a way to select all pods
+                              within a set of Namespaces. Note that host-networked
+                              pods are not included in this type of peer. \n Support:
+                              Core"
                             maxProperties: 1
                             minProperties: 1
                             properties:
@@ -241,7 +243,9 @@ spec:
                             type: object
                           pods:
                             description: "Pods defines a way to select a set of pods
-                              in in a set of namespaces. \n Support: Core"
+                              in in a set of namespaces. Note that host-networked
+                              pods are not included in this type of peer. \n Support:
+                              Core"
                             properties:
                               namespaces:
                                 description: "Namespaces is used to select a set of
@@ -432,8 +436,10 @@ spec:
                         minProperties: 1
                         properties:
                           namespaces:
-                            description: "Namespaces defines a way to select a set
-                              of Namespaces. \n Support: Core"
+                            description: "Namespaces defines a way to select all pods
+                              within a set of Namespaces. Note that host-networked
+                              pods are not included in this type of peer. \n Support:
+                              Core"
                             maxProperties: 1
                             minProperties: 1
                             properties:
@@ -516,7 +522,9 @@ spec:
                             type: object
                           pods:
                             description: "Pods defines a way to select a set of pods
-                              in in a set of namespaces. \n Support: Core"
+                              in in a set of namespaces. Note that host-networked
+                              pods are not included in this type of peer. \n Support:
+                              Core"
                             properties:
                               namespaces:
                                 description: "Namespaces is used to select a set of

--- a/config/crd/standard/policy.networking.k8s.io_adminnetworkpolicies.yaml
+++ b/config/crd/standard/policy.networking.k8s.io_adminnetworkpolicies.yaml
@@ -161,8 +161,10 @@ spec:
                         minProperties: 1
                         properties:
                           namespaces:
-                            description: "Namespaces defines a way to select a set
-                              of Namespaces. \n Support: Core"
+                            description: "Namespaces defines a way to select all pods
+                              within a set of Namespaces. Note that host-networked
+                              pods are not included in this type of peer. \n Support:
+                              Core"
                             maxProperties: 1
                             minProperties: 1
                             properties:
@@ -220,7 +222,9 @@ spec:
                             type: object
                           pods:
                             description: "Pods defines a way to select a set of pods
-                              in in a set of namespaces. \n Support: Core"
+                              in in a set of namespaces. Note that host-networked
+                              pods are not included in this type of peer. \n Support:
+                              Core"
                             properties:
                               namespaces:
                                 description: "Namespaces is used to select a set of
@@ -390,8 +394,10 @@ spec:
                         minProperties: 1
                         properties:
                           namespaces:
-                            description: "Namespaces defines a way to select a set
-                              of Namespaces. \n Support: Core"
+                            description: "Namespaces defines a way to select all pods
+                              within a set of Namespaces. Note that host-networked
+                              pods are not included in this type of peer. \n Support:
+                              Core"
                             maxProperties: 1
                             minProperties: 1
                             properties:
@@ -449,7 +455,9 @@ spec:
                             type: object
                           pods:
                             description: "Pods defines a way to select a set of pods
-                              in in a set of namespaces. \n Support: Core"
+                              in in a set of namespaces. Note that host-networked
+                              pods are not included in this type of peer. \n Support:
+                              Core"
                             properties:
                               namespaces:
                                 description: "Namespaces is used to select a set of

--- a/config/crd/standard/policy.networking.k8s.io_baselineadminnetworkpolicies.yaml
+++ b/config/crd/standard/policy.networking.k8s.io_baselineadminnetworkpolicies.yaml
@@ -153,8 +153,10 @@ spec:
                         minProperties: 1
                         properties:
                           namespaces:
-                            description: "Namespaces defines a way to select a set
-                              of Namespaces. \n Support: Core"
+                            description: "Namespaces defines a way to select all pods
+                              within a set of Namespaces. Note that host-networked
+                              pods are not included in this type of peer. \n Support:
+                              Core"
                             maxProperties: 1
                             minProperties: 1
                             properties:
@@ -212,7 +214,9 @@ spec:
                             type: object
                           pods:
                             description: "Pods defines a way to select a set of pods
-                              in in a set of namespaces. \n Support: Core"
+                              in in a set of namespaces. Note that host-networked
+                              pods are not included in this type of peer. \n Support:
+                              Core"
                             properties:
                               namespaces:
                                 description: "Namespaces is used to select a set of
@@ -377,8 +381,10 @@ spec:
                         minProperties: 1
                         properties:
                           namespaces:
-                            description: "Namespaces defines a way to select a set
-                              of Namespaces. \n Support: Core"
+                            description: "Namespaces defines a way to select all pods
+                              within a set of Namespaces. Note that host-networked
+                              pods are not included in this type of peer. \n Support:
+                              Core"
                             maxProperties: 1
                             minProperties: 1
                             properties:
@@ -436,7 +442,9 @@ spec:
                             type: object
                           pods:
                             description: "Pods defines a way to select a set of pods
-                              in in a set of namespaces. \n Support: Core"
+                              in in a set of namespaces. Note that host-networked
+                              pods are not included in this type of peer. \n Support:
+                              Core"
                             properties:
                               namespaces:
                                 description: "Namespaces is used to select a set of


### PR DESCRIPTION
As discussed in sig-network-policy-api meeting 10th October
/assign @astoycos @Dyanngg 