### PR TITLE
add shellcheck verification step to makefile

### DIFF
--- a/hack/build-install-yaml.sh
+++ b/hack/build-install-yaml.sh
@@ -17,8 +17,8 @@
 set -o errexit
 set -o nounset
 set -o pipefail
-
-thisyear=`date +"%Y"`
+shopt -s nullglob
+thisyear=$(date +"%Y")
 
 mkdir -p release/
 
@@ -39,22 +39,28 @@ cat << EOF >> release/standard-install.yaml
 #
 EOF
 
-for file in `ls config/crd/experimental/policy*.yaml`
+for file in config/crd/experimental/policy*.yaml
 do
-    echo "---" >> release/experimental-install.yaml
-    echo "#" >> release/experimental-install.yaml
-    echo "# $file" >> release/experimental-install.yaml
-    echo "#" >> release/experimental-install.yaml
-    cat $file >> release/experimental-install.yaml
+    [[ -e "$file" ]] || break;
+    {
+      echo "---"
+      echo "#"
+      echo "# $file"
+      echo "#"
+      cat "$file"
+    } >> release/experimental-install.yaml
 done
 
-for file in `ls config/crd/standard/policy*.yaml`
+for file in config/crd/standard/policy*.yaml
 do
-    echo "---" >> release/standard-install.yaml
-    echo "#" >> release/standard-install.yaml
-    echo "# $file" >> release/standard-install.yaml
-    echo "#" >> release/standard-install.yaml
-    cat $file >> release/standard-install.yaml
+    [[ -e "$file" ]] || break;
+    {
+      echo "---"
+      echo "#"
+      echo "# $file"
+      echo "#"
+      cat "$file"
+    } >> release/standard-install.yaml
 done
 
 

--- a/hack/crd-e2e.sh
+++ b/hack/crd-e2e.sh
@@ -18,8 +18,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly GOPATH="$(mktemp -d)"
-readonly CLUSTER_NAME="verify-network-policy-api"
+GOPATH="$(mktemp -d)"
+readonly GOPATH
+CLUSTER_NAME="verify-network-policy-api"
+readonly CLUSTER_NAME
 
 export KUBECONFIG="${GOPATH}/.kubeconfig"
 export GOFLAGS GO111MODULE GOPATH
@@ -49,8 +51,9 @@ res=0
 # Create cluster
 KIND_CREATE_ATTEMPTED=true
 kind create cluster --name "${CLUSTER_NAME}" || res=$?
-
-for KUST_FOLDER in bases patches; do
+#echo $bases
+#echo $patches
+for _ in bases patches; do
   go run sigs.k8s.io/controller-tools/cmd/controller-gen rbac:roleName=manager-role crd paths=./apis/... output:crd:dir=./config/crd/bases output:stdout || res=$?
   kubectl kustomize config/crd | kubectl apply -f - || res=$?
 

--- a/hack/kube-env.sh
+++ b/hack/kube-env.sh
@@ -18,9 +18,13 @@
 if [[ -z "${color_start-}" ]]; then
   declare -r color_start="\033["
   declare -r color_red="${color_start}0;31m"
+  export color_red
   declare -r color_yellow="${color_start}0;33m"
+  export color_yellow
   declare -r color_green="${color_start}0;32m"
+  export color_green
   declare -r color_norm="${color_start}0m"
+  export color_norm
 fi
 
 # Returns the server version as MMmmpp, with MM as the major
@@ -37,8 +41,8 @@ function kube_server_version() {
   # Server Version: &version.Info{Major:"0", Minor:"7+", GitVersion:"v0.7.0-dirty", GitCommit:"ad44234f7152e9c66bc2853575445c7071335e57", GitTreeState:"dirty"}
   # and capture the GitVersion portion (which has the patch level)
   server_version=$(${KUBECTL} --match-server-version=false version | grep "Server Version:")
-  read major minor patch < <(
-    echo ${server_version} | \
+  read -r major minor patch < <(
+    echo "${server_version}" | \
       sed "s/.*GitVersion:\"v\([0-9]\{1,\}\)\.\([0-9]\{1,\}\)\.\([0-9]\{1,\}\).*/\1 \2 \3/")
-  printf "%02d%02d%02d" ${major} ${minor} ${patch} | sed 's/^0*//'
+  printf "%02d%02d%02d" "${major}" "${minor}" "${patch}" | sed 's/^0*//'
 }

--- a/hack/make-docs.sh
+++ b/hack/make-docs.sh
@@ -18,8 +18,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly SCRIPT_ROOT
 SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
+readonly SCRIPT_ROOT
 cd "$SCRIPT_ROOT"
 
 # Wrap sed to deal with GNU and BSD sed flags.

--- a/hack/make-docs.sh
+++ b/hack/make-docs.sh
@@ -18,8 +18,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE}")"/.. && pwd)"
-cd $SCRIPT_ROOT
+readonly SCRIPT_ROOT
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
+cd "$SCRIPT_ROOT"
 
 # Wrap sed to deal with GNU and BSD sed flags.
 run::sed() {

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -18,14 +18,17 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE}")"/.. && pwd)"
+readonly SCRIPT_ROOT
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
 
 # Keep outer module cache so we don't need to redownload them each time.
 # The build cache already is persisted.
-readonly GOMODCACHE="$(go env GOMODCACHE)"
+readonly GOMODCACHE
+GOMODCACHE="$(go env GOMODCACHE)"
 readonly GO111MODULE="on"
 readonly GOFLAGS="-mod=readonly"
-readonly GOPATH="$(mktemp -d)"
+readonly GOPATH
+GOPATH="$(mktemp -d)"
 readonly MIN_REQUIRED_GO_VER="1.19"
 
 function go_version_matches {
@@ -63,13 +66,13 @@ go run k8s.io/code-generator/cmd/client-gen \
 --input-base "" \
 --input "${API_DIR}" \
 --output-package "${OUTPUT_PKG}/${CLIENTSET_PKG_NAME}" \
-${COMMON_FLAGS}
+"${COMMON_FLAGS}"
 
 echo "Generating listers at ${OUTPUT_PKG}/listers"
 go run k8s.io/code-generator/cmd/lister-gen \
 --input-dirs "${API_DIR}" \
 --output-package "${OUTPUT_PKG}/listers" \
-${COMMON_FLAGS}
+"${COMMON_FLAGS}"
 
 echo "Generating informers at ${OUTPUT_PKG}/informers"
 go run k8s.io/code-generator/cmd/informer-gen \
@@ -77,18 +80,17 @@ go run k8s.io/code-generator/cmd/informer-gen \
 --versioned-clientset-package "${OUTPUT_PKG}/${CLIENTSET_PKG_NAME}/${CLIENTSET_NAME}" \
 --listers-package "${OUTPUT_PKG}/listers" \
 --output-package "${OUTPUT_PKG}/informers" \
-${COMMON_FLAGS}
+"${COMMON_FLAGS}"
 
-for VERSION in v1alpha1 ## Add more versions eventually
-do
-  echo "Generating ${VERSION} register at ${APIS_PKG}/apis/${VERSION}"
-  go run k8s.io/code-generator/cmd/register-gen \
+VERSION=v1alpha1 ## Add more versions eventually
+echo "Generating ${VERSION} register at ${APIS_PKG}/apis/${VERSION}"
+go run k8s.io/code-generator/cmd/register-gen \
     --input-dirs "${APIS_PKG}/apis/${VERSION}" \
     --output-package "${APIS_PKG}/apis/${VERSION}" \
-    ${COMMON_FLAGS}
+    "${COMMON_FLAGS}"
 
-  echo "Generating ${VERSION} deepcopy at ${APIS_PKG}/apis/${VERSION}"
-  go run sigs.k8s.io/controller-tools/cmd/controller-gen \
-    object:headerFile=${SCRIPT_ROOT}/hack/boilerplate.generatego.txt \
+echo "Generating ${VERSION} deepcopy at ${APIS_PKG}/apis/${VERSION}"
+go run sigs.k8s.io/controller-tools/cmd/controller-gen \
+    object:headerFile="${SCRIPT_ROOT}"/hack/boilerplate.generatego.txt \
     paths="${APIS_PKG}/apis/${VERSION}" 
-done
+

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2086
+#Double quote to prevent globbing and word splitting. dont apply for this specific scenario
 
 # Copyright 2020 The Kubernetes Authors.
 #
@@ -18,17 +20,17 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly SCRIPT_ROOT
 SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
+readonly SCRIPT_ROOT
 
 # Keep outer module cache so we don't need to redownload them each time.
 # The build cache already is persisted.
-readonly GOMODCACHE
 GOMODCACHE="$(go env GOMODCACHE)"
+readonly GOMODCACHE
 readonly GO111MODULE="on"
 readonly GOFLAGS="-mod=readonly"
-readonly GOPATH
 GOPATH="$(mktemp -d)"
+readonly GOPATH
 readonly MIN_REQUIRED_GO_VER="1.19"
 
 function go_version_matches {
@@ -66,13 +68,13 @@ go run k8s.io/code-generator/cmd/client-gen \
 --input-base "" \
 --input "${API_DIR}" \
 --output-package "${OUTPUT_PKG}/${CLIENTSET_PKG_NAME}" \
-"${COMMON_FLAGS}"
+${COMMON_FLAGS}
 
 echo "Generating listers at ${OUTPUT_PKG}/listers"
 go run k8s.io/code-generator/cmd/lister-gen \
 --input-dirs "${API_DIR}" \
 --output-package "${OUTPUT_PKG}/listers" \
-"${COMMON_FLAGS}"
+${COMMON_FLAGS}
 
 echo "Generating informers at ${OUTPUT_PKG}/informers"
 go run k8s.io/code-generator/cmd/informer-gen \
@@ -80,17 +82,16 @@ go run k8s.io/code-generator/cmd/informer-gen \
 --versioned-clientset-package "${OUTPUT_PKG}/${CLIENTSET_PKG_NAME}/${CLIENTSET_NAME}" \
 --listers-package "${OUTPUT_PKG}/listers" \
 --output-package "${OUTPUT_PKG}/informers" \
-"${COMMON_FLAGS}"
+${COMMON_FLAGS}
 
-VERSION=v1alpha1 ## Add more versions eventually
+VERSION=v1alpha1
 echo "Generating ${VERSION} register at ${APIS_PKG}/apis/${VERSION}"
 go run k8s.io/code-generator/cmd/register-gen \
-    --input-dirs "${APIS_PKG}/apis/${VERSION}" \
-    --output-package "${APIS_PKG}/apis/${VERSION}" \
-    "${COMMON_FLAGS}"
+--input-dirs "${APIS_PKG}/apis/${VERSION}" \
+--output-package "${APIS_PKG}/apis/${VERSION}" \
+${COMMON_FLAGS}
 
 echo "Generating ${VERSION} deepcopy at ${APIS_PKG}/apis/${VERSION}"
 go run sigs.k8s.io/controller-tools/cmd/controller-gen \
-    object:headerFile="${SCRIPT_ROOT}"/hack/boilerplate.generatego.txt \
-    paths="${APIS_PKG}/apis/${VERSION}" 
-
+object:headerFile="${SCRIPT_ROOT}/hack/boilerplate.generatego.txt" \
+paths="${APIS_PKG}/apis/${VERSION}"

--- a/hack/verify-all.sh
+++ b/hack/verify-all.sh
@@ -17,15 +17,16 @@
 set -o errexit
 set -o nounset
 set -o pipefail
+shopt -s nullglob
 
-SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")/..
+SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${SCRIPT_ROOT}/hack/kube-env.sh"
 
 SILENT=true
 
 function is-excluded {
   for e in $EXCLUDE; do
-    if [[ $1 -ef ${BASH_SOURCE} ]]; then
+    if [[ $1 -ef ${BASH_SOURCE[0]} ]]; then
       return
     fi
     if [[ $1 -ef "$SCRIPT_ROOT/hack/$e" ]]; then
@@ -54,9 +55,10 @@ fi
 EXCLUDE="verify-all.sh"
 
 ret=0
-for t in `ls $SCRIPT_ROOT/hack/verify-*.sh`
+for t in "$SCRIPT_ROOT"/hack/verify-*.sh
 do
-  if is-excluded $t ; then
+  [[ -e "$t" ]] || break;
+  if is-excluded "$t" ; then
     echo "Skipping $t"
     continue
   fi

--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")/..
+SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 make -C "$SCRIPT_ROOT" generate
 

--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -19,8 +19,8 @@ set -o nounset
 set -o pipefail
 
 readonly VERSION="v1.55.2"
-readonly KUBE_ROOT
 KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+readonly KUBE_ROOT
 
 cd "${KUBE_ROOT}"
 

--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -19,7 +19,8 @@ set -o nounset
 set -o pipefail
 
 readonly VERSION="v1.55.2"
-readonly KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+readonly KUBE_ROOT
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 cd "${KUBE_ROOT}"
 

--- a/hack/verify-govet.sh
+++ b/hack/verify-govet.sh
@@ -18,6 +18,8 @@ set -euo pipefail
 
 echo "Verifying govet"
 
-go vet "$(go list ./... | grep -v vendor)"
+for key in $(go list ./... | grep -v vendor); do
+    go vet "$key"
+done
 
 echo "Done"

--- a/hack/verify-govet.sh
+++ b/hack/verify-govet.sh
@@ -18,6 +18,6 @@ set -euo pipefail
 
 echo "Verifying govet"
 
-go vet $(go list ./... | grep -v vendor)
+go vet "$(go list ./... | grep -v vendor)"
 
 echo "Done"

--- a/hack/verify-shellcheck.sh
+++ b/hack/verify-shellcheck.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+readonly VERSION="v0.9.0"
+OWNER=koalaman
+REPO="shellcheck"
+BINARY=shellcheck
+FORMAT=tar.xz
+#supported OS's linux and darwin
+#supported cpu architectures: 
+#linux: x86_64, aarch64, armv6hf
+#darwin: x86_64 (only this architecture because the official shellcheck repo only delivers this binary)
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+GITHUB_DOWNLOAD=https://github.com/${OWNER}/${REPO}/releases/download
+NAME=${BINARY}-${VERSION}.${OS}.${ARCH}
+TARBALL=${NAME}.${FORMAT}
+TARBALL_URL=${GITHUB_DOWNLOAD}/${VERSION}/${TARBALL}
+BINDIR=${BINDIR:-./bin}
+
+echo "Installing shellcheck..."
+
+http_download_curl() {
+  local_file=$1
+  source_url=$2
+  code=$(curl -w '%{http_code}' -sL -o "$local_file" "$source_url")
+  if [ "$code" != "200" ]; then
+    log_debug "http_download_curl received HTTP status $code"
+    return 1
+  fi
+  return 0
+}
+
+tmpdir=$(mktemp -d)
+http_download_curl "${tmpdir}/${TARBALL}" "${TARBALL_URL}"
+srcdir="${tmpdir}/${NAME}"
+rm -rf "${srcdir}"
+(cd "${tmpdir}" && tar --no-same-owner -xf "${TARBALL}")
+binexe="./shellcheck-${VERSION}/shellcheck"
+install "${tmpdir}/${binexe}" "${BINDIR}/"
+rm -rf "${tmpdir}"
+
+echo "Running shellcheck scan..."
+
+#scanning all .sh scripts inside the hack directory
+./bin/shellcheck hack/*.sh

--- a/hack/verify-shellcheck.sh
+++ b/hack/verify-shellcheck.sh
@@ -60,4 +60,5 @@ rm -rf "${tmpdir}"
 echo "Running shellcheck scan..."
 
 #scanning all .sh scripts inside the hack directory
-./bin/shellcheck hack/*.sh
+#ignoring SC2001 in shellcheck because complex sed substitution is required.
+./bin/shellcheck -e SC2001 hack/*.sh


### PR DESCRIPTION
Hi.

This is to resolve https://github.com/kubernetes-sigs/network-policy-api/issues/94

This [install.sh](https://raw.githubusercontent.com/gabrielggg/shellcheck/master/install.sh) file is a script i created to simplify the instalation of shellcheck, it is a fork from this script https://github.com/golangci/golangci-lint/blob/master/install.sh which is used on the verify-golint.sh script from this repo. If you want i can upload that script also here, now it is hosted on my personal repo.

I took the same approach you used on https://github.com/kubernetes-sigs/network-policy-api/issues/37 creating a verify-shellcheck.sh script so that it gets automatically included on the ci pipeline because of the hack/verify-all.sh script wildcard usage.

p.s. This is my first PR to a kubernetes project, so i hope everything goes well.