### PR TITLE
Correct typo from 'protocall' to 'protocol'

### DIFF
--- a/docs/legacydocs/stories/pod_reachability_query.md
+++ b/docs/legacydocs/stories/pod_reachability_query.md
@@ -3,7 +3,7 @@
 ## User Story
 
 As a policy creator or developer, I want to query the network policy enforcement
-engine to ask if a specific type of network traffic (IP protocall and port) is
+engine to ask if a specific type of network traffic (IP protocol and port) is
 permissible between two pods in a specific direction. If this is not
 permissible, I would like the query results to explain what policies (either
 egress and/or ingress) prevented the network connection.


### PR DESCRIPTION
## Description

Correct typo from 'protocall' to 'protocol'.