### PR TITLE
Add validation for ANP/BANP Enum actions

### DIFF
--- a/apis/v1alpha1/adminnetworkpolicy_types.go
+++ b/apis/v1alpha1/adminnetworkpolicy_types.go
@@ -210,6 +210,7 @@ type AdminNetworkPolicyEgressRule struct {
 // Support: Core
 //
 // +enum
+// +kubebuilder:validation:Enum={"Allow", "Deny", "Pass"}
 type AdminNetworkPolicyRuleAction string
 
 const (

--- a/apis/v1alpha1/baselineadminnetworkpolicy_types.go
+++ b/apis/v1alpha1/baselineadminnetworkpolicy_types.go
@@ -188,6 +188,7 @@ type BaselineAdminNetworkPolicyEgressRule struct {
 // Support: Core
 //
 // +enum
+// +kubebuilder:validation:Enum={"Allow", "Deny"}
 type BaselineAdminNetworkPolicyRuleAction string
 
 const (

--- a/config/crd/experimental/policy.networking.k8s.io_adminnetworkpolicies.yaml
+++ b/config/crd/experimental/policy.networking.k8s.io_adminnetworkpolicies.yaml
@@ -83,6 +83,10 @@ spec:
 
 
                         Support: Core
+                      enum:
+                      - Allow
+                      - Deny
+                      - Pass
                       type: string
                     name:
                       description: |-
@@ -501,6 +505,10 @@ spec:
 
 
                         Support: Core
+                      enum:
+                      - Allow
+                      - Deny
+                      - Pass
                       type: string
                     from:
                       description: |-

--- a/config/crd/experimental/policy.networking.k8s.io_baselineadminnetworkpolicies.yaml
+++ b/config/crd/experimental/policy.networking.k8s.io_baselineadminnetworkpolicies.yaml
@@ -77,6 +77,9 @@ spec:
 
 
                         Support: Core
+                      enum:
+                      - Allow
+                      - Deny
                       type: string
                     name:
                       description: |-
@@ -489,6 +492,9 @@ spec:
 
 
                         Support: Core
+                      enum:
+                      - Allow
+                      - Deny
                       type: string
                     from:
                       description: |-

--- a/config/crd/standard/policy.networking.k8s.io_adminnetworkpolicies.yaml
+++ b/config/crd/standard/policy.networking.k8s.io_adminnetworkpolicies.yaml
@@ -83,6 +83,10 @@ spec:
 
 
                         Support: Core
+                      enum:
+                      - Allow
+                      - Deny
+                      - Pass
                       type: string
                     name:
                       description: |-
@@ -401,6 +405,10 @@ spec:
 
 
                         Support: Core
+                      enum:
+                      - Allow
+                      - Deny
+                      - Pass
                       type: string
                     from:
                       description: |-

--- a/config/crd/standard/policy.networking.k8s.io_baselineadminnetworkpolicies.yaml
+++ b/config/crd/standard/policy.networking.k8s.io_baselineadminnetworkpolicies.yaml
@@ -77,6 +77,9 @@ spec:
 
 
                         Support: Core
+                      enum:
+                      - Allow
+                      - Deny
                       type: string
                     name:
                       description: |-
@@ -389,6 +392,9 @@ spec:
 
 
                         Support: Core
+                      enum:
+                      - Allow
+                      - Deny
                       type: string
                     from:
                       description: |-


### PR DESCRIPTION
Credit to @asood-rh who put `pass` and `allow` instead of `Pass` and `Allow` which causes panic (I admit panic was too much over-reaction on the implementation side, but really this needs to be fixed in the API because we clearly state what our enum allowed values are and we don't want to have confusion on `pass`, `Pass`, `PASS` etc).

Tested output with this fix:
`The AdminNetworkPolicy "node-as-egress-peers" is invalid: spec.egress[0].action: Unsupported value: "allow": supported values: "Allow", "Deny", "Pass"`