### PR TITLE
Fix tests to reflect newAPI changes

### DIFF
--- a/conformance/base/admin_network_policy/core-egress-sctp-rules.yaml
+++ b/conformance/base/admin_network_policy/core-egress-sctp-rules.yaml
@@ -13,30 +13,26 @@ spec:
     action: "Allow"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-gryffindor
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-gryffindor
   - name: "deny-to-gryffindor-everything"
     action: "Deny"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-gryffindor
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-gryffindor
   - name: "pass-to-gryffindor-everything"
     action: "Pass"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-gryffindor
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-gryffindor
   - name: "deny-to-slytherin-at-port-9003"
     action: "Deny"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-slytherin
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-slytherin
     ports:
       - portNumber:
           protocol: SCTP
@@ -45,9 +41,8 @@ spec:
     action: "Pass"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-slytherin
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-slytherin
     ports:
       - portNumber:
           protocol: SCTP
@@ -56,9 +51,8 @@ spec:
     action: "Allow"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
     ports:
       - portNumber:
           protocol: SCTP
@@ -67,6 +61,5 @@ spec:
     action: "Deny"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-hufflepuff

--- a/conformance/base/admin_network_policy/core-egress-tcp-rules.yaml
+++ b/conformance/base/admin_network_policy/core-egress-tcp-rules.yaml
@@ -13,30 +13,26 @@ spec:
     action: "Allow"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
   - name: "deny-to-ravenclaw-everything"
     action: "Deny"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
   - name: "pass-to-ravenclaw-everything"
     action: "Pass"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
   - name: "deny-to-slytherin-at-port-80"
     action: "Deny"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-slytherin
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-slytherin
     ports:
       - portNumber:
           protocol: TCP
@@ -45,9 +41,8 @@ spec:
     action: "Pass"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-slytherin
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-slytherin
     ports:
       - portNumber:
           protocol: TCP
@@ -56,9 +51,8 @@ spec:
     action: "Allow"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
     ports:
       - portNumber:
           protocol: TCP
@@ -67,6 +61,5 @@ spec:
     action: "Deny"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-hufflepuff

--- a/conformance/base/admin_network_policy/core-egress-udp-rules.yaml
+++ b/conformance/base/admin_network_policy/core-egress-udp-rules.yaml
@@ -13,30 +13,26 @@ spec:
     action: "Allow"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
   - name: "deny-to-ravenclaw-everything"
     action: "Deny"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
   - name: "pass-to-ravenclaw-everything"
     action: "Pass"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
   - name: "deny-to-slytherin-at-port-5353"
     action: "Deny"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-slytherin
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-slytherin
     ports:
       - portNumber:
           protocol: UDP
@@ -45,9 +41,8 @@ spec:
     action: "Pass"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-slytherin
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-slytherin
     ports:
       - portNumber:
           protocol: UDP
@@ -56,9 +51,8 @@ spec:
     action: "Allow"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-gryffindor
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-gryffindor
     ports:
       - portNumber:
           protocol: UDP
@@ -67,6 +61,5 @@ spec:
     action: "Deny"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-gryffindor
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-gryffindor

--- a/conformance/base/admin_network_policy/core-gress-rules-combined.yaml
+++ b/conformance/base/admin_network_policy/core-gress-rules-combined.yaml
@@ -13,30 +13,26 @@ spec:
     action: "Allow"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
   - name: "deny-to-ravenclaw-everything"
     action: "Deny"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
   - name: "pass-to-ravenclaw-everything"
     action: "Pass"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
   - name: "deny-to-slytherin-at-ports-80-53-9003"
     action: "Deny"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-slytherin
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-slytherin
     ports:
       - portNumber:
           protocol: TCP
@@ -51,9 +47,8 @@ spec:
     action: "Pass"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-slytherin
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-slytherin
     ports:
       - portNumber:
           protocol: TCP
@@ -68,9 +63,8 @@ spec:
     action: "Allow"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
     ports:
       - portNumber:
           protocol: TCP
@@ -85,38 +79,33 @@ spec:
     action: "Deny"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
   ingress:
   - name: "allow-from-ravenclaw-everything"
     action: "Allow"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
   - name: "deny-from-ravenclaw-everything"
     action: "Deny"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
   - name: "pass-from-ravenclaw-everything"
     action: "Pass"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
   - name: "deny-from-slytherin-at-port-80-53-9003"
     action: "Deny"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-slytherin
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-slytherin
     ports:
       - portNumber:
           protocol: TCP
@@ -131,9 +120,8 @@ spec:
     action: "Pass"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-slytherin
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-slytherin
     ports:
       - portNumber:
           protocol: TCP
@@ -148,9 +136,8 @@ spec:
     action: "Allow"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
     ports:
       - portNumber:
           protocol: TCP
@@ -165,6 +152,5 @@ spec:
     action: "Deny"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-hufflepuff

--- a/conformance/base/admin_network_policy/core-ingress-sctp-rules.yaml
+++ b/conformance/base/admin_network_policy/core-ingress-sctp-rules.yaml
@@ -13,30 +13,26 @@ spec:
     action: "Allow"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-gryffindor
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-gryffindor
   - name: "deny-from-gryffindor-everything"
     action: "Deny"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-gryffindor
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-gryffindor
   - name: "pass-from-gryffindor-everything"
     action: "Pass"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-gryffindor
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-gryffindor
   - name: "deny-from-slytherin-at-port-9003"
     action: "Deny"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-slytherin
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-slytherin
     ports:
       - portNumber:
           protocol: SCTP
@@ -45,9 +41,8 @@ spec:
     action: "Pass"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-slytherin
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-slytherin
     ports:
       - portNumber:
           protocol: SCTP
@@ -56,9 +51,8 @@ spec:
     action: "Allow"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
     ports:
       - portNumber:
           protocol: SCTP
@@ -67,6 +61,5 @@ spec:
     action: "Deny"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-hufflepuff

--- a/conformance/base/admin_network_policy/core-ingress-tcp-rules.yaml
+++ b/conformance/base/admin_network_policy/core-ingress-tcp-rules.yaml
@@ -13,30 +13,26 @@ spec:
     action: "Allow"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
   - name: "deny-from-ravenclaw-everything"
     action: "Deny"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
   - name: "pass-from-ravenclaw-everything"
     action: "Pass"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
   - name: "deny-from-slytherin-at-port-80"
     action: "Deny"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-slytherin
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-slytherin
     ports:
       - portNumber:
           protocol: TCP
@@ -45,9 +41,8 @@ spec:
     action: "Pass"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-slytherin
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-slytherin
     ports:
       - portNumber:
           protocol: TCP
@@ -56,9 +51,8 @@ spec:
     action: "Allow"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
     ports:
       - portNumber:
           protocol: TCP
@@ -67,6 +61,5 @@ spec:
     action: "Deny"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-hufflepuff

--- a/conformance/base/admin_network_policy/core-ingress-udp-rules.yaml
+++ b/conformance/base/admin_network_policy/core-ingress-udp-rules.yaml
@@ -13,30 +13,26 @@ spec:
     action: "Allow"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
   - name: "deny-from-ravenclaw-everything"
     action: "Deny"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
   - name: "pass-from-ravenclaw-everything"
     action: "Pass"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
   - name: "deny-from-slytherin-at-port-5353"
     action: "Deny"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-slytherin
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-slytherin
     ports:
       - portNumber:
           protocol: UDP
@@ -45,9 +41,8 @@ spec:
     action: "Pass"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-slytherin
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-slytherin
     ports:
       - portNumber:
           protocol: UDP
@@ -56,9 +51,8 @@ spec:
     action: "Allow"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-gryffindor
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-gryffindor
     ports:
       - portNumber:
           protocol: UDP
@@ -67,6 +61,5 @@ spec:
     action: "Deny"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-gryffindor
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-gryffindor

--- a/conformance/base/admin_network_policy/core-priority-field.yaml
+++ b/conformance/base/admin_network_policy/core-priority-field.yaml
@@ -17,10 +17,9 @@ spec:
     action: "Deny"
     from:
     - pods:
-        namespaces:
-          namespaceSelector:
-            matchLabels:
-              conformance-house: slytherin
+        namespaceSelector:
+          matchLabels:
+            conformance-house: slytherin
         podSelector:
           matchLabels:
             conformance-house: slytherin
@@ -29,10 +28,9 @@ spec:
     action: "Deny"
     to:
     - pods:
-        namespaces:
-          namespaceSelector:
-            matchLabels:
-              conformance-house: slytherin
+        namespaceSelector:
+          matchLabels:
+            conformance-house: slytherin
         podSelector:
           matchLabels:
             conformance-house: slytherin
@@ -56,10 +54,9 @@ spec:
     action: "Pass"
     from:
     - pods:
-        namespaces:
-          namespaceSelector:
-            matchLabels:
-              conformance-house: slytherin
+        namespaceSelector:
+          matchLabels:
+            conformance-house: slytherin
         podSelector:
           matchLabels:
             conformance-house: slytherin
@@ -68,10 +65,9 @@ spec:
     action: "Pass"
     to:
     - pods:
-        namespaces:
-          namespaceSelector:
-            matchLabels:
-              conformance-house: slytherin
+        namespaceSelector:
+          matchLabels:
+            conformance-house: slytherin
         podSelector:
           matchLabels:
             conformance-house: slytherin
@@ -94,10 +90,9 @@ spec:
     action: "Allow"
     from:
     - pods:
-        namespaces:
-          namespaceSelector:
-            matchLabels:
-              conformance-house: slytherin
+        namespaceSelector:
+          matchLabels:
+            conformance-house: slytherin
         podSelector:
           matchLabels:
             conformance-house: slytherin
@@ -106,10 +101,9 @@ spec:
     action: "Allow"
     to:
     - pods:
-        namespaces:
-          namespaceSelector:
-            matchLabels:
-              conformance-house: slytherin
+        namespaceSelector:
+          matchLabels:
+            conformance-house: slytherin
         podSelector:
           matchLabels:
             conformance-house: slytherin

--- a/conformance/base/admin_network_policy/extended-egress-selector-rules.yaml
+++ b/conformance/base/admin_network_policy/extended-egress-selector-rules.yaml
@@ -37,10 +37,9 @@ spec:
     action: "Deny"
     to:
     - pods:
-        namespaces:
-          namespaceSelector:
-            matchLabels:
-              conformance-house: slytherin
+        namespaceSelector:
+          matchLabels:
+            conformance-house: slytherin
         podSelector:
           matchLabels:
             conformance-house: slytherin

--- a/conformance/base/api_integration/core-anp-np-banp.yaml
+++ b/conformance/base/api_integration/core-anp-np-banp.yaml
@@ -13,17 +13,15 @@ spec:
     action: "Deny" # test will update to pass
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            conformance-house: slytherin
+        matchLabels:
+          conformance-house: slytherin
   egress:
   - name: "deny-all-egress-to-slytherin" # test will update to pass
     action: "Deny" # test will update to pass
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            conformance-house: slytherin
+        matchLabels:
+          conformance-house: slytherin
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -60,14 +58,12 @@ spec:
     action: "Deny"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            conformance-house: slytherin
+        matchLabels:
+          conformance-house: slytherin
   egress:
   - name: "deny-all-egress-to-slytherin"
     action: "Deny"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            conformance-house: slytherin
+        matchLabels:
+          conformance-house: slytherin

--- a/conformance/base/baseline_admin_network_policy/core-egress-sctp-rules.yaml
+++ b/conformance/base/baseline_admin_network_policy/core-egress-sctp-rules.yaml
@@ -12,23 +12,20 @@ spec:
     action: "Allow"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-gryffindor
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-gryffindor
   - name: "deny-to-gryffindor-everything"
     action: "Deny"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-gryffindor
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-gryffindor
   - name: "deny-to-slytherin-at-port-9003"
     action: "Deny"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-slytherin
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-slytherin
     ports:
       - portNumber:
           protocol: SCTP
@@ -37,9 +34,8 @@ spec:
     action: "Allow"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
     ports:
       - portNumber:
           protocol: SCTP
@@ -48,6 +44,5 @@ spec:
     action: "Deny"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-hufflepuff

--- a/conformance/base/baseline_admin_network_policy/core-egress-tcp-rules.yaml
+++ b/conformance/base/baseline_admin_network_policy/core-egress-tcp-rules.yaml
@@ -12,23 +12,20 @@ spec:
     action: "Allow"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
   - name: "deny-to-ravenclaw-everything"
     action: "Deny"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
   - name: "deny-to-slytherin-at-port-80"
     action: "Deny"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-slytherin
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-slytherin
     ports:
       - portNumber:
           protocol: TCP
@@ -37,9 +34,8 @@ spec:
     action: "Allow"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
     ports:
       - portNumber:
           protocol: TCP
@@ -48,6 +44,5 @@ spec:
     action: "Deny"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-hufflepuff

--- a/conformance/base/baseline_admin_network_policy/core-egress-udp-rules.yaml
+++ b/conformance/base/baseline_admin_network_policy/core-egress-udp-rules.yaml
@@ -12,23 +12,20 @@ spec:
     action: "Allow"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
   - name: "deny-to-ravenclaw-everything"
     action: "Deny"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
   - name: "deny-to-slytherin-at-port-5353"
     action: "Deny"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-slytherin
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-slytherin
     ports:
       - portNumber:
           protocol: UDP
@@ -37,9 +34,8 @@ spec:
     action: "Allow"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-gryffindor
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-gryffindor
     ports:
       - portNumber:
           protocol: UDP
@@ -48,6 +44,5 @@ spec:
     action: "Deny"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-gryffindor
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-gryffindor

--- a/conformance/base/baseline_admin_network_policy/core-gress-rules-combined.yaml
+++ b/conformance/base/baseline_admin_network_policy/core-gress-rules-combined.yaml
@@ -12,23 +12,20 @@ spec:
     action: "Allow"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
   - name: "deny-to-ravenclaw-everything"
     action: "Deny"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
   - name: "deny-to-slytherin-at-ports-80-53-9003"
     action: "Deny"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-slytherin
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-slytherin
     ports:
       - portNumber:
           protocol: TCP
@@ -43,9 +40,8 @@ spec:
     action: "Allow"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
     ports:
       - portNumber:
           protocol: TCP
@@ -60,31 +56,27 @@ spec:
     action: "Deny"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
   ingress:
   - name: "allow-from-ravenclaw-everything"
     action: "Allow"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
   - name: "deny-from-ravenclaw-everything"
     action: "Deny"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
   - name: "deny-from-slytherin-at-port-80-53-9003"
     action: "Deny"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-slytherin
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-slytherin
     ports:
       - portNumber:
           protocol: TCP
@@ -99,9 +91,8 @@ spec:
     action: "Allow"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
     ports:
       - portNumber:
           protocol: TCP
@@ -116,6 +107,5 @@ spec:
     action: "Deny"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-hufflepuff

--- a/conformance/base/baseline_admin_network_policy/core-ingress-sctp-rules.yaml
+++ b/conformance/base/baseline_admin_network_policy/core-ingress-sctp-rules.yaml
@@ -12,23 +12,20 @@ spec:
     action: "Allow"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-gryffindor
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-gryffindor
   - name: "deny-from-gryffindor-everything"
     action: "Deny"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-gryffindor
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-gryffindor
   - name: "deny-from-slytherin-at-port-9003"
     action: "Deny"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-slytherin
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-slytherin
     ports:
       - portNumber:
           protocol: SCTP
@@ -37,9 +34,8 @@ spec:
     action: "Allow"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
     ports:
       - portNumber:
           protocol: SCTP
@@ -48,6 +44,5 @@ spec:
     action: "Deny"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-hufflepuff

--- a/conformance/base/baseline_admin_network_policy/core-ingress-tcp-rules.yaml
+++ b/conformance/base/baseline_admin_network_policy/core-ingress-tcp-rules.yaml
@@ -12,23 +12,20 @@ spec:
     action: "Allow"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
   - name: "deny-from-ravenclaw-everything"
     action: "Deny"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
   - name: "deny-from-slytherin-at-port-80"
     action: "Deny"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-slytherin
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-slytherin
     ports:
       - portNumber:
           protocol: TCP
@@ -37,9 +34,8 @@ spec:
     action: "Allow"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
     ports:
       - portNumber:
           protocol: TCP
@@ -48,6 +44,5 @@ spec:
     action: "Deny"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-hufflepuff

--- a/conformance/base/baseline_admin_network_policy/core-ingress-udp-rules.yaml
+++ b/conformance/base/baseline_admin_network_policy/core-ingress-udp-rules.yaml
@@ -12,23 +12,20 @@ spec:
     action: "Allow"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
   - name: "deny-from-ravenclaw-everything"
     action: "Deny"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-ravenclaw
   - name: "deny-from-slytherin-at-port-5353"
     action: "Deny"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-slytherin
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-slytherin
     ports:
       - portNumber:
           protocol: UDP
@@ -37,9 +34,8 @@ spec:
     action: "Allow"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-gryffindor
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-gryffindor
     ports:
       - portNumber:
           protocol: UDP
@@ -48,6 +44,5 @@ spec:
     action: "Deny"
     from:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: network-policy-conformance-gryffindor
+        matchLabels:
+          kubernetes.io/metadata.name: network-policy-conformance-gryffindor


### PR DESCRIPTION
We fixed the peer API to be symmetric to the subject API via https://github.com/kubernetes-sigs/network-policy-api/pull/196

Let's change this to also reflect on the test cases.

So change:
```
- namespaces:
        namespaceSelector:
          matchLabels:
```
to 
```
- namespaces:
          matchLabels:
```
in peers everywhere