### PR TITLE
Change udp port listeners on host-net pods

### DIFF
--- a/conformance/base/admin_network_policy/extended-egress-selector-rules.yaml
+++ b/conformance/base/admin_network_policy/extended-egress-selector-rules.yaml
@@ -32,7 +32,7 @@ spec:
     ports:
       - portNumber:
           protocol: UDP
-          port: 5353
+          port: 34345
   - name: "deny-egress-to-slytherin-and-nodes-and-internet"
     action: "Deny"
     to:

--- a/conformance/base/manifests.yaml
+++ b/conformance/base/manifests.yaml
@@ -55,35 +55,35 @@ spec:
     spec:
       containers:
         - name: harry-potter-client
-          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+          image: registry.k8s.io/e2e-test-images/agnhost:2.45
         - name: harry-potter-80
-          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+          image: registry.k8s.io/e2e-test-images/agnhost:2.45
           command: ["/bin/bash", "-c", "/agnhost serve-hostname --tcp --http=false --port 80"]
           ports:
             - containerPort: 80
               protocol: TCP
               name: web
         - name: harry-potter-8080
-          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+          image: registry.k8s.io/e2e-test-images/agnhost:2.45
           command: ["/bin/bash", "-c", "/agnhost serve-hostname --tcp --http=false --port 8080"]
         - name: harry-potter-5353
-          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+          image: registry.k8s.io/e2e-test-images/agnhost:2.45
           command: ["/bin/bash", "-c", "/agnhost serve-hostname --udp --http=false --port 5353"]
         - name: harry-potter-53
-          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+          image: registry.k8s.io/e2e-test-images/agnhost:2.45
           command: ["/bin/bash", "-c", "/agnhost serve-hostname --udp --http=false --port 53"]
           ports:
             - containerPort: 53
               protocol: UDP
               name: dns
         - name: harry-potter-9003
-          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+          image: registry.k8s.io/e2e-test-images/agnhost:2.45
           command: ["/bin/bash", "-c", "/agnhost porter"]
           env:
           - name: SERVE_SCTP_PORT_9003
             value: "foo"
         - name: harry-potter-9005
-          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+          image: registry.k8s.io/e2e-test-images/agnhost:2.45
           command: ["/bin/bash", "-c", "/agnhost porter"]
           env:
           - name: SERVE_SCTP_PORT_9005
@@ -106,35 +106,35 @@ spec:
     spec:
       containers:
         - name: draco-malfoy-client
-          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+          image: registry.k8s.io/e2e-test-images/agnhost:2.45
         - name: draco-malfoy-80
-          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+          image: registry.k8s.io/e2e-test-images/agnhost:2.45
           command: ["/bin/bash", "-c", "/agnhost serve-hostname --tcp --http=false --port 80"]
           ports:
             - containerPort: 80
               protocol: TCP
               name: web
         - name: draco-malfoy-8080
-          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+          image: registry.k8s.io/e2e-test-images/agnhost:2.45
           command: ["/bin/bash", "-c", "/agnhost serve-hostname --tcp --http=false --port 8080"]
         - name: draco-malfoy-5353
-          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+          image: registry.k8s.io/e2e-test-images/agnhost:2.45
           command: ["/bin/bash", "-c", "/agnhost serve-hostname --udp --http=false --port 5353"]
         - name: draco-malfoy-53
-          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+          image: registry.k8s.io/e2e-test-images/agnhost:2.45
           command: ["/bin/bash", "-c", "/agnhost serve-hostname --udp --http=false --port 53"]
           ports:
             - containerPort: 53
               protocol: UDP
               name: dns
         - name: draco-malfoy-9003
-          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+          image: registry.k8s.io/e2e-test-images/agnhost:2.45
           command: ["/bin/bash", "-c", "/agnhost porter"]
           env:
           - name: SERVE_SCTP_PORT_9003
             value: "foo"
         - name: draco-malfoy-9005
-          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+          image: registry.k8s.io/e2e-test-images/agnhost:2.45
           command: ["/bin/bash", "-c", "/agnhost porter"]
           env:
           - name: SERVE_SCTP_PORT_9005
@@ -157,35 +157,35 @@ spec:
     spec:
       containers:
         - name: cedric-diggory-client
-          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+          image: registry.k8s.io/e2e-test-images/agnhost:2.45
         - name: cedric-diggory-80
-          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+          image: registry.k8s.io/e2e-test-images/agnhost:2.45
           command: ["/bin/bash", "-c", "/agnhost serve-hostname --tcp --http=false --port 80"]
           ports:
             - containerPort: 80
               protocol: TCP
               name: web
         - name: cedric-diggory-8080
-          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+          image: registry.k8s.io/e2e-test-images/agnhost:2.45
           command: ["/bin/bash", "-c", "/agnhost serve-hostname --tcp --http=false --port 8080"]
         - name: cedric-diggory-5353
-          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+          image: registry.k8s.io/e2e-test-images/agnhost:2.45
           command: ["/bin/bash", "-c", "/agnhost serve-hostname --udp --http=false --port 5353"]
         - name: cedric-diggory-53
-          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+          image: registry.k8s.io/e2e-test-images/agnhost:2.45
           command: ["/bin/bash", "-c", "/agnhost serve-hostname --udp --http=false --port 53"]
           ports:
             - containerPort: 53
               protocol: UDP
               name: dns
         - name: cedric-diggory-9003
-          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+          image: registry.k8s.io/e2e-test-images/agnhost:2.45
           command: ["/bin/bash", "-c", "/agnhost porter"]
           env:
           - name: SERVE_SCTP_PORT_9003
             value: "foo"
         - name: cedric-diggory-9005
-          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+          image: registry.k8s.io/e2e-test-images/agnhost:2.45
           command: ["/bin/bash", "-c", "/agnhost porter"]
           env:
           - name: SERVE_SCTP_PORT_9005
@@ -208,35 +208,35 @@ spec:
     spec:
       containers:
         - name: luna-lovegood-client
-          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+          image: registry.k8s.io/e2e-test-images/agnhost:2.45
         - name: luna-lovegood-80
-          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+          image: registry.k8s.io/e2e-test-images/agnhost:2.45
           command: ["/bin/bash", "-c", "/agnhost serve-hostname --tcp --http=false --port 80"]
           ports:
             - containerPort: 80
               protocol: TCP
               name: web
         - name: luna-lovegood-8080
-          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+          image: registry.k8s.io/e2e-test-images/agnhost:2.45
           command: ["/bin/bash", "-c", "/agnhost serve-hostname --tcp --http=false --port 8080"]
         - name: luna-lovegood-5353
-          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+          image: registry.k8s.io/e2e-test-images/agnhost:2.45
           command: ["/bin/bash", "-c", "/agnhost serve-hostname --udp --http=false --port 5353"]
         - name: luna-lovegood-53
-          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+          image: registry.k8s.io/e2e-test-images/agnhost:2.45
           command: ["/bin/bash", "-c", "/agnhost serve-hostname --udp --http=false --port 53"]
           ports:
             - containerPort: 53
               protocol: UDP
               name: dns
         - name: luna-lovegood-9003
-          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+          image: registry.k8s.io/e2e-test-images/agnhost:2.45
           command: ["/bin/bash", "-c", "/agnhost porter"]
           env:
           - name: SERVE_SCTP_PORT_9003
             value: "foo"
         - name: luna-lovegood-9005
-          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+          image: registry.k8s.io/e2e-test-images/agnhost:2.45
           command: ["/bin/bash", "-c", "/agnhost porter"]
           env:
           - name: SERVE_SCTP_PORT_9005
@@ -260,39 +260,55 @@ spec:
       hostNetwork: true
       containers:
         - name: centaur-client
-          image: registry.k8s.io/e2e-test-images/agnhost:2.43
-        - name: centaur-36363
-          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+          image: registry.k8s.io/e2e-test-images/agnhost:2.45
+        - name: centaur-36363-tcp
+          image: registry.k8s.io/e2e-test-images/agnhost:2.45
           command: ["/bin/bash", "-c", "/agnhost serve-hostname --tcp --http=false --port 36363"]
           ports:
             - containerPort: 36363
               protocol: TCP
               name: web-36363
-        - name: centaur-36364
-          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+        - name: centaur-36364-tcp
+          image: registry.k8s.io/e2e-test-images/agnhost:2.45
           command: ["/bin/bash", "-c", "/agnhost serve-hostname --tcp --http=false --port 36364"]
           ports:
             - containerPort: 36364
               protocol: TCP
               name: web-36364
-        - name: centaur-5353
-          image: registry.k8s.io/e2e-test-images/agnhost:2.43
-          command: ["/bin/bash", "-c", "/agnhost serve-hostname --udp --http=false --port 5353"]
-        - name: centaur-53
-          image: registry.k8s.io/e2e-test-images/agnhost:2.43
-          command: ["/bin/bash", "-c", "/agnhost serve-hostname --udp --http=false --port 53"]
+        - name: centaur-34345-udp
+          image: registry.k8s.io/e2e-test-images/agnhost:2.45
+          # using random http port to avoid conflict with processes on the host (there is no way to disable http port on netexec)
+          command: ["/bin/bash", "-c", "/agnhost netexec --http-port 34358 --udp-port 34345 --udp-listen-addresses $(HOST_IP)"]
           ports:
-            - containerPort: 53
+            - containerPort: 34345
               protocol: UDP
-              name: dns
+              name: dns-34345
+          env:
+          - name: HOST_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+        - name: centaur-34346-udp
+          image: registry.k8s.io/e2e-test-images/agnhost:2.45
+          # using random http port to avoid conflict with processes on the host (there is no way to disable http port on netexec)
+          command: ["/bin/bash", "-c", "/agnhost netexec --http-port 34357 --udp-port 34346 --udp-listen-addresses $(HOST_IP)"]
+          ports:
+            - containerPort: 34346
+              protocol: UDP
+              name: dns-34346
+          env:
+          - name: HOST_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
         - name: centaur-9003
-          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+          image: registry.k8s.io/e2e-test-images/agnhost:2.45
           command: ["/bin/bash", "-c", "/agnhost porter"]
           env:
           - name: SERVE_SCTP_PORT_9003
             value: "foo"
         - name: centaur-9005
-          image: registry.k8s.io/e2e-test-images/agnhost:2.43
+          image: registry.k8s.io/e2e-test-images/agnhost:2.45
           command: ["/bin/bash", "-c", "/agnhost porter"]
           env:
           - name: SERVE_SCTP_PORT_9005

--- a/conformance/tests/admin-network-policy-extended-egress-rules.go
+++ b/conformance/tests/admin-network-policy-extended-egress-rules.go
@@ -121,10 +121,10 @@ var AdminNetworkPolicyEgressNodePeers = suite.ConformanceTest{
 		})
 		t.Run("Should support a 'pass-egress' rule policy for egress-node-peer", func(t *testing.T) {
 			// harry-potter-0 is our client pod in gryffindor namespace
-			// ensure egress is PASSED to forbidden-forrest from gryffindor at the 5353 UDP port
+			// ensure egress is PASSED to forbidden-forrest from gryffindor at the 34345 UDP port
 			// egressRule at index1 should take effect
 			success := kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "udp",
-				serverPod.Status.PodIP, int32(5353), s.TimeoutConfig.RequestTimeout, true) // Pass rule at index2 takes effect
+				serverPod.Status.PodIP, int32(34345), s.TimeoutConfig.RequestTimeout, true) // Pass rule at index2 takes effect
 			assert.True(t, success)
 		})
 		t.Run("Should support a 'deny-egress' rule policy for egress-node-peer", func(t *testing.T) {
@@ -134,7 +134,7 @@ var AdminNetworkPolicyEgressNodePeers = suite.ConformanceTest{
 				serverPod.Status.PodIP, int32(36364), s.TimeoutConfig.RequestTimeout, false)
 			assert.True(t, success)
 			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "udp",
-				serverPod.Status.PodIP, int32(53), s.TimeoutConfig.RequestTimeout, false)
+				serverPod.Status.PodIP, int32(34346), s.TimeoutConfig.RequestTimeout, false)
 			assert.True(t, success)
 			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "sctp",
 				serverPod.Status.PodIP, int32(9003), s.TimeoutConfig.RequestTimeout, false)

--- a/conformance/tests/baseline-admin-network-policy-extended-egress-rules.go
+++ b/conformance/tests/baseline-admin-network-policy-extended-egress-rules.go
@@ -125,7 +125,7 @@ var BaselineAdminNetworkPolicyEgressNodePeers = suite.ConformanceTest{
 			// harry-potter-1 is our client pod in gryffindor namespace
 			// ensure egress is DENIED to rest of the nodes from gryffindor; egressRule at index1 should take effect
 			success := kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "udp",
-				serverPod.Status.PodIP, int32(53), s.TimeoutConfig.RequestTimeout, false)
+				serverPod.Status.PodIP, int32(34346), s.TimeoutConfig.RequestTimeout, false)
 			assert.True(t, success)
 			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "sctp",
 				serverPod.Status.PodIP, int32(9003), s.TimeoutConfig.RequestTimeout, false)


### PR DESCRIPTION
Like reported in https://github.com/kubernetes/kubernetes/issues/95565 we saw flakes in https://github.com/ovn-org/ovn-kubernetes/pull/4235 as we were enabling nodes peer tests because agnhost was misbehaving by replying from a seconary nodeIP address instead of using the primary one which is not desired.

With this PR:
```
root@ovn-worker:/# conntrack -E | grep udp
    [NEW] udp      17 30 src=10.244.0.10 dst=172.19.0.4 sport=42832 dport=34345 [UNREPLIED] src=172.19.0.4 dst=10.244.0.10 sport=34345 dport=42832 zone=19
    [NEW] udp      17 30 src=10.244.0.10 dst=172.19.0.4 sport=42832 dport=34345 [UNREPLIED] src=172.19.0.4 dst=10.244.0.10 sport=34345 dport=42832 zone=15
    [NEW] udp      17 30 src=10.244.0.10 dst=172.19.0.4 sport=42832 dport=34345 [UNREPLIED] src=172.19.0.4 dst=10.244.0.10 sport=34345 dport=42832
 [UPDATE] udp      17 30 src=10.244.0.10 dst=172.19.0.4 sport=42832 dport=34345 src=172.19.0.4 dst=10.244.0.10 sport=34345 dport=42832
```
Without this PR:
```
    [NEW] udp      17 30 src=10.244.0.10 dst=172.19.0.4 sport=38612 dport=34346 [UNREPLIED] src=172.19.0.4 dst=10.244.0.10 sport=34346 dport=38612 zone=19
    [NEW] udp      17 30 src=10.244.0.10 dst=172.19.0.4 sport=38612 dport=34346 [UNREPLIED] src=172.19.0.4 dst=10.244.0.10 sport=34346 dport=38612 zone=15
    [NEW] udp      17 30 src=10.244.0.10 dst=172.19.0.4 sport=38612 dport=34346 [UNREPLIED] src=172.19.0.4 dst=10.244.0.10 sport=34346 dport=38612
    [NEW] udp      17 30 src=10.244.0.2 dst=10.244.0.10 sport=34346 dport=38612 [UNREPLIED] src=10.244.0.10 dst=10.244.0.2 sport=38612 dport=34346
    [NEW] udp      17 30 src=10.244.0.2 dst=10.244.0.10 sport=34346 dport=38612 [UNREPLIED] src=10.244.0.10 dst=10.244.0.2 sport=38612 dport=34346 zone=15
    [NEW] udp      17 30 src=10.244.0.2 dst=10.244.0.10 sport=34346 dport=38612 [UNREPLIED] src=10.244.0.10 dst=10.244.0.2 sport=38612 dport=34346 zone=19
```

also don't use well known ports like 53 and 5353 for host-networked pod tests as those ports can already be in use on the host.