### PR TITLE
Do patch instead of update

### DIFF
--- a/conformance/tests/admin-network-policy-core-egress-sctp-rules.go
+++ b/conformance/tests/admin-network-policy-core-egress-sctp-rules.go
@@ -107,12 +107,13 @@ var AdminNetworkPolicyEgressSCTP = suite.ConformanceTest{
 				Name: "egress-sctp",
 			}, anp)
 			require.NoErrorf(t, err, "unable to fetch the admin network policy")
+			mutate := anp.DeepCopy()
 			// swap rules at index0 and index1
-			allowRule := anp.DeepCopy().Spec.Egress[0]
-			anp.Spec.Egress[0] = anp.DeepCopy().Spec.Egress[1]
-			anp.Spec.Egress[1] = allowRule
-			err = s.Client.Update(ctx, anp)
-			require.NoErrorf(t, err, "unable to update the admin network policy")
+			allowRule := mutate.Spec.Egress[0]
+			mutate.Spec.Egress[0] = mutate.Spec.Egress[1]
+			mutate.Spec.Egress[1] = allowRule
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(anp))
+			require.NoErrorf(t, err, "unable to patch the admin network policy")
 			// luna-lovegood-0 is our client pod in gryffindor namespace
 			// ensure egress is DENIED to gryffindor from ravenclaw
 			// egressRule at index0 will take precedence over egressRule at index1; thus DENY takes precedence over ALLOW since rules are ordered
@@ -164,12 +165,13 @@ var AdminNetworkPolicyEgressSCTP = suite.ConformanceTest{
 				Name: "egress-sctp",
 			}, anp)
 			require.NoErrorf(t, err, "unable to fetch the admin network policy")
+			mutate := anp.DeepCopy()
 			// swap rules at index0 and index2
-			denyRule := anp.DeepCopy().Spec.Egress[0]
-			anp.Spec.Egress[0] = anp.DeepCopy().Spec.Egress[2]
-			anp.Spec.Egress[2] = denyRule
-			err = s.Client.Update(ctx, anp)
-			require.NoErrorf(t, err, "unable to update the admin network policy")
+			denyRule := mutate.Spec.Egress[0]
+			mutate.Spec.Egress[0] = mutate.Spec.Egress[2]
+			mutate.Spec.Egress[2] = denyRule
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(anp))
+			require.NoErrorf(t, err, "unable to patch the admin network policy")
 			// luna-lovegood-0 is our client pod in ravenclaw namespace
 			// ensure egress is PASSED from gryffindor to ravenclaw
 			// egressRule at index0 will take precedence over egressRule at index1&index2; thus PASS takes precedence over ALLOW/DENY since rules are ordered
@@ -198,12 +200,13 @@ var AdminNetworkPolicyEgressSCTP = suite.ConformanceTest{
 				Name: "egress-sctp",
 			}, anp)
 			require.NoErrorf(t, err, "unable to fetch the admin network policy")
+			mutate := anp.DeepCopy()
 			// swap rules at index3 and index4
-			denyRule := anp.DeepCopy().Spec.Egress[3]
-			anp.Spec.Egress[3] = anp.DeepCopy().Spec.Egress[4]
-			anp.Spec.Egress[4] = denyRule
-			err = s.Client.Update(ctx, anp)
-			require.NoErrorf(t, err, "unable to update the admin network policy")
+			denyRule := mutate.Spec.Egress[3]
+			mutate.Spec.Egress[3] = mutate.Spec.Egress[4]
+			mutate.Spec.Egress[4] = denyRule
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(anp))
+			require.NoErrorf(t, err, "unable to patch the admin network policy")
 			// luna-lovegood-0 is our client pod in ravenclaw namespace
 			// ensure egress to slytherin is PASSED from ravenclaw at port 9003; egressRule at index3 should take effect
 			success := kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-ravenclaw", "luna-lovegood-0", "sctp",

--- a/conformance/tests/admin-network-policy-core-egress-tcp-rules.go
+++ b/conformance/tests/admin-network-policy-core-egress-tcp-rules.go
@@ -33,7 +33,6 @@ import (
 func init() {
 	ConformanceTests = append(ConformanceTests,
 		AdminNetworkPolicyEgressTCP,
-		AdminNetworkPolicyEgressNamedPort,
 	)
 }
 
@@ -107,12 +106,13 @@ var AdminNetworkPolicyEgressTCP = suite.ConformanceTest{
 				Name: "egress-tcp",
 			}, anp)
 			require.NoErrorf(t, err, "unable to fetch the admin network policy")
+			mutate := anp.DeepCopy()
 			// swap rules at index0 and index1
-			allowRule := anp.DeepCopy().Spec.Egress[0]
-			anp.Spec.Egress[0] = anp.DeepCopy().Spec.Egress[1]
-			anp.Spec.Egress[1] = allowRule
-			err = s.Client.Update(ctx, anp)
-			require.NoErrorf(t, err, "unable to update the admin network policy")
+			allowRule := mutate.Spec.Egress[0]
+			mutate.Spec.Egress[0] = mutate.Spec.Egress[1]
+			mutate.Spec.Egress[1] = allowRule
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(anp))
+			require.NoErrorf(t, err, "unable to patch the admin network policy")
 			// harry-potter-0 is our client pod in gryffindor namespace
 			// ensure egress is DENIED to ravenclaw from gryffindor
 			// egressRule at index0 will take precedence over egressRule at index1; thus DENY takes precedence over ALLOW since rules are ordered
@@ -164,12 +164,13 @@ var AdminNetworkPolicyEgressTCP = suite.ConformanceTest{
 				Name: "egress-tcp",
 			}, anp)
 			require.NoErrorf(t, err, "unable to fetch the admin network policy")
+			mutate := anp.DeepCopy()
 			// swap rules at index0 and index2
-			denyRule := anp.DeepCopy().Spec.Egress[0]
-			anp.Spec.Egress[0] = anp.DeepCopy().Spec.Egress[2]
-			anp.Spec.Egress[2] = denyRule
-			err = s.Client.Update(ctx, anp)
-			require.NoErrorf(t, err, "unable to update the admin network policy")
+			denyRule := mutate.Spec.Egress[0]
+			mutate.Spec.Egress[0] = mutate.Spec.Egress[2]
+			mutate.Spec.Egress[2] = denyRule
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(anp))
+			require.NoErrorf(t, err, "unable to patch the admin network policy")
 			// harry-potter-0 is our server pod in gryffindor namespace
 			// ensure egress is PASSED from gryffindor to ravenclaw
 			// egressRule at index0 will take precedence over egressRule at index1&index2; thus PASS takes precedence over ALLOW/DENY since rules are ordered
@@ -198,12 +199,13 @@ var AdminNetworkPolicyEgressTCP = suite.ConformanceTest{
 				Name: "egress-tcp",
 			}, anp)
 			require.NoErrorf(t, err, "unable to fetch the admin network policy")
+			mutate := anp.DeepCopy()
 			// swap rules at index3 and index4
-			denyRule := anp.DeepCopy().Spec.Egress[3]
-			anp.Spec.Egress[3] = anp.DeepCopy().Spec.Egress[4]
-			anp.Spec.Egress[4] = denyRule
-			err = s.Client.Update(ctx, anp)
-			require.NoErrorf(t, err, "unable to update the admin network policy")
+			denyRule := mutate.Spec.Egress[3]
+			mutate.Spec.Egress[3] = mutate.Spec.Egress[4]
+			mutate.Spec.Egress[4] = denyRule
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(anp))
+			require.NoErrorf(t, err, "unable to patch the admin network policy")
 			// harry-potter-0 is our client pod in gryffindor namespace
 			// ensure egress from gryffindor is PASSED to slytherin at port 80; egressRule at index3 should take effect
 			success := kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-0", "tcp",

--- a/conformance/tests/admin-network-policy-core-egress-udp-rules.go
+++ b/conformance/tests/admin-network-policy-core-egress-udp-rules.go
@@ -107,12 +107,13 @@ var AdminNetworkPolicyEgressUDP = suite.ConformanceTest{
 				Name: "egress-udp",
 			}, anp)
 			require.NoErrorf(t, err, "unable to fetch the admin network policy")
+			mutate := anp.DeepCopy()
 			// swap rules at index0 and index1
-			allowRule := anp.DeepCopy().Spec.Egress[0]
-			anp.Spec.Egress[0] = anp.DeepCopy().Spec.Egress[1]
-			anp.Spec.Egress[1] = allowRule
-			err = s.Client.Update(ctx, anp)
-			require.NoErrorf(t, err, "unable to update the admin network policy")
+			allowRule := mutate.Spec.Egress[0]
+			mutate.Spec.Egress[0] = mutate.Spec.Egress[1]
+			mutate.Spec.Egress[1] = allowRule
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(anp))
+			require.NoErrorf(t, err, "unable to patch the admin network policy")
 			// cedric-diggory-0 is our client pod in hufflepuff namespace
 			// ensure egress is DENIED to ravenclaw to hufflepuff
 			// egressRule at index0 will take precedence over egressRule at index1; thus DENY takes precedence over ALLOW since rules are ordered
@@ -164,12 +165,13 @@ var AdminNetworkPolicyEgressUDP = suite.ConformanceTest{
 				Name: "egress-udp",
 			}, anp)
 			require.NoErrorf(t, err, "unable to fetch the admin network policy")
+			mutate := anp.DeepCopy()
 			// swap rules at index0 and index2
-			denyRule := anp.DeepCopy().Spec.Egress[0]
-			anp.Spec.Egress[0] = anp.DeepCopy().Spec.Egress[2]
-			anp.Spec.Egress[2] = denyRule
-			err = s.Client.Update(ctx, anp)
-			require.NoErrorf(t, err, "unable to update the admin network policy")
+			denyRule := mutate.Spec.Egress[0]
+			mutate.Spec.Egress[0] = mutate.Spec.Egress[2]
+			mutate.Spec.Egress[2] = denyRule
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(anp))
+			require.NoErrorf(t, err, "unable to patch the admin network policy")
 			// cedric-diggory-0 is our client pod in hufflepuff namespace
 			// ensure egress is PASSED to ravenclaw from hufflepuff
 			// egressRule at index0 will take precedence over egressRule at index1&index2; thus PASS takes precedence over ALLOW/DENY since rules are ordered
@@ -198,12 +200,13 @@ var AdminNetworkPolicyEgressUDP = suite.ConformanceTest{
 				Name: "egress-udp",
 			}, anp)
 			require.NoErrorf(t, err, "unable to fetch the admin network policy")
+			mutate := anp.DeepCopy()
 			// swap rules at index3 and index4
-			denyRule := anp.DeepCopy().Spec.Egress[3]
-			anp.Spec.Egress[3] = anp.DeepCopy().Spec.Egress[4]
-			anp.Spec.Egress[4] = denyRule
-			err = s.Client.Update(ctx, anp)
-			require.NoErrorf(t, err, "unable to update the admin network policy")
+			denyRule := mutate.Spec.Egress[3]
+			mutate.Spec.Egress[3] = mutate.Spec.Egress[4]
+			mutate.Spec.Egress[4] = denyRule
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(anp))
+			require.NoErrorf(t, err, "unable to patch the admin network policy")
 			// cedric-diggory-0 is our client pod in hufflepuff namespace
 			// ensure egress to slytherin is PASSED from hufflepuff at port 5353; egressRule at index3 should take effect
 			success := kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-hufflepuff", "cedric-diggory-0", "udp",

--- a/conformance/tests/admin-network-policy-core-gress-rules.go
+++ b/conformance/tests/admin-network-policy-core-gress-rules.go
@@ -193,15 +193,16 @@ var AdminNetworkPolicyGress = suite.ConformanceTest{
 				Name: "gress-rules",
 			}, anp)
 			require.NoErrorf(t, err, "unable to fetch the admin network policy")
+			mutate := anp.DeepCopy()
 			// swap rules at index0 and index1 for both ingress and egress
-			allowOutRule := anp.DeepCopy().Spec.Egress[0]
-			anp.Spec.Egress[0] = anp.DeepCopy().Spec.Egress[1]
-			anp.Spec.Egress[1] = allowOutRule
-			allowInRule := anp.DeepCopy().Spec.Ingress[0]
-			anp.Spec.Ingress[0] = anp.DeepCopy().Spec.Ingress[1]
-			anp.Spec.Ingress[1] = allowInRule
-			err = s.Client.Update(ctx, anp)
-			require.NoErrorf(t, err, "unable to update the admin network policy")
+			allowOutRule := mutate.Spec.Egress[0]
+			mutate.Spec.Egress[0] = mutate.Spec.Egress[1]
+			mutate.Spec.Egress[1] = allowOutRule
+			allowInRule := mutate.Spec.Ingress[0]
+			mutate.Spec.Ingress[0] = mutate.Spec.Ingress[1]
+			mutate.Spec.Ingress[1] = allowInRule
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(anp))
+			require.NoErrorf(t, err, "unable to patch the admin network policy")
 			// harry-potter-x is our client pod in gryffindor namespace
 			// ensure egress is DENIED to ravenclaw from gryffindor
 			// egressRule at index0 will take precedence over egressRule at index1; thus DENY takes precedence over ALLOW since rules are ordered
@@ -337,15 +338,16 @@ var AdminNetworkPolicyGress = suite.ConformanceTest{
 				Name: "gress-rules",
 			}, anp)
 			require.NoErrorf(t, err, "unable to fetch the admin network policy")
+			mutate := anp.DeepCopy()
 			// swap rules at index0 and index2 for both ingress and egress
-			denyOutRule := anp.DeepCopy().Spec.Egress[0]
-			anp.Spec.Egress[0] = anp.DeepCopy().Spec.Egress[2]
-			anp.Spec.Egress[2] = denyOutRule
-			denyInRule := anp.DeepCopy().Spec.Ingress[0]
-			anp.Spec.Ingress[0] = anp.DeepCopy().Spec.Ingress[2]
-			anp.Spec.Ingress[2] = denyInRule
-			err = s.Client.Update(ctx, anp)
-			require.NoErrorf(t, err, "unable to update the admin network policy")
+			denyOutRule := mutate.Spec.Egress[0]
+			mutate.Spec.Egress[0] = mutate.Spec.Egress[2]
+			mutate.Spec.Egress[2] = denyOutRule
+			denyInRule := mutate.Spec.Ingress[0]
+			mutate.Spec.Ingress[0] = mutate.Spec.Ingress[2]
+			mutate.Spec.Ingress[2] = denyInRule
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(anp))
+			require.NoErrorf(t, err, "unable to patch the admin network policy")
 			// harry-potter-0 is our server pod in gryffindor namespace
 			// ensure egress is PASSED from gryffindor to ravenclaw
 			// egressRule at index0 will take precedence over egressRule at index1&index2; thus PASS takes precedence over ALLOW/DENY since rules are ordered
@@ -406,15 +408,16 @@ var AdminNetworkPolicyGress = suite.ConformanceTest{
 				Name: "gress-rules",
 			}, anp)
 			require.NoErrorf(t, err, "unable to fetch the admin network policy")
+			mutate := anp.DeepCopy()
 			// swap rules at index3 and index4
-			denyToRule := anp.DeepCopy().Spec.Egress[3]
-			anp.Spec.Egress[3] = anp.DeepCopy().Spec.Egress[4]
-			anp.Spec.Egress[4] = denyToRule
-			denyInRule := anp.DeepCopy().Spec.Ingress[3]
-			anp.Spec.Ingress[3] = anp.DeepCopy().Spec.Ingress[4]
-			anp.Spec.Ingress[4] = denyInRule
-			err = s.Client.Update(ctx, anp)
-			require.NoErrorf(t, err, "unable to update the admin network policy")
+			denyToRule := mutate.Spec.Egress[3]
+			mutate.Spec.Egress[3] = mutate.Spec.Egress[4]
+			mutate.Spec.Egress[4] = denyToRule
+			denyInRule := mutate.Spec.Ingress[3]
+			mutate.Spec.Ingress[3] = mutate.Spec.Ingress[4]
+			mutate.Spec.Ingress[4] = denyInRule
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(anp))
+			require.NoErrorf(t, err, "unable to patch the admin network policy")
 			// harry-potter-0 is our client pod in gryffindor namespace
 			// ensure egress from gryffindor is PASSED to slytherin at port 80; egressRule at index3 should take effect
 			success := kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-0", "tcp",

--- a/conformance/tests/admin-network-policy-core-ingress-sctp-rules.go
+++ b/conformance/tests/admin-network-policy-core-ingress-sctp-rules.go
@@ -106,12 +106,13 @@ var AdminNetworkPolicyIngressSCTP = suite.ConformanceTest{
 				Name: "ingress-sctp",
 			}, anp)
 			require.NoErrorf(t, err, "unable to fetch the admin network policy")
+			mutate := anp.DeepCopy()
 			// swap rules at index0 and index1
-			allowRule := anp.DeepCopy().Spec.Ingress[0]
-			anp.Spec.Ingress[0] = anp.DeepCopy().Spec.Ingress[1]
-			anp.Spec.Ingress[1] = allowRule
-			err = s.Client.Update(ctx, anp)
-			require.NoErrorf(t, err, "unable to update the admin network policy")
+			allowRule := mutate.Spec.Ingress[0]
+			mutate.Spec.Ingress[0] = mutate.Spec.Ingress[1]
+			mutate.Spec.Ingress[1] = allowRule
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(anp))
+			require.NoErrorf(t, err, "unable to patch the admin network policy")
 			// harry-potter-0 is our client pod in gryffindor namespace
 			// ensure ingress is DENIED from gryffindor to ravenclaw
 			// ingressRule at index0 will take precedence over ingressRule at index1; thus DENY takes precedence over ALLOW since rules are ordered
@@ -163,12 +164,13 @@ var AdminNetworkPolicyIngressSCTP = suite.ConformanceTest{
 				Name: "ingress-sctp",
 			}, anp)
 			require.NoErrorf(t, err, "unable to fetch the admin network policy")
+			mutate := anp.DeepCopy()
 			// swap rules at index0 and index2
-			denyRule := anp.DeepCopy().Spec.Ingress[0]
-			anp.Spec.Ingress[0] = anp.DeepCopy().Spec.Ingress[2]
-			anp.Spec.Ingress[2] = denyRule
-			err = s.Client.Update(ctx, anp)
-			require.NoErrorf(t, err, "unable to update the admin network policy")
+			denyRule := mutate.Spec.Ingress[0]
+			mutate.Spec.Ingress[0] = mutate.Spec.Ingress[2]
+			mutate.Spec.Ingress[2] = denyRule
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(anp))
+			require.NoErrorf(t, err, "unable to patch the admin network policy")
 			// harry-potter-0 is our client pod in gryffindor namespace
 			// ensure ingress is PASSED from gryffindor to ravenclaw
 			// ingressRule at index0 will take precedence over ingressRule at index1&index2; thus PASS takes precedence over ALLOW/DENY since rules are ordered
@@ -197,12 +199,13 @@ var AdminNetworkPolicyIngressSCTP = suite.ConformanceTest{
 				Name: "ingress-sctp",
 			}, anp)
 			require.NoErrorf(t, err, "unable to fetch the admin network policy")
+			mutate := anp.DeepCopy()
 			// swap rules at index3 and index4
-			denyRule := anp.DeepCopy().Spec.Ingress[3]
-			anp.Spec.Ingress[3] = anp.DeepCopy().Spec.Ingress[4]
-			anp.Spec.Ingress[4] = denyRule
-			err = s.Client.Update(ctx, anp)
-			require.NoErrorf(t, err, "unable to update the admin network policy")
+			denyRule := mutate.Spec.Ingress[3]
+			mutate.Spec.Ingress[3] = mutate.Spec.Ingress[4]
+			mutate.Spec.Ingress[4] = denyRule
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(anp))
+			require.NoErrorf(t, err, "unable to patch the admin network policy")
 			// draco-malfoy-0 is our client pod in slytherin namespace
 			// ensure ingress from slytherin is PASSED to ravenclaw at port 9003; ingressRule at index3 should take effect
 			success := kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-slytherin", "draco-malfoy-0", "sctp",

--- a/conformance/tests/admin-network-policy-core-ingress-tcp-rules.go
+++ b/conformance/tests/admin-network-policy-core-ingress-tcp-rules.go
@@ -106,12 +106,13 @@ var AdminNetworkPolicyIngressTCP = suite.ConformanceTest{
 				Name: "ingress-tcp",
 			}, anp)
 			require.NoErrorf(t, err, "unable to fetch the admin network policy")
+			mutate := anp.DeepCopy()
 			// swap rules at index0 and index1
-			allowRule := anp.DeepCopy().Spec.Ingress[0]
-			anp.Spec.Ingress[0] = anp.DeepCopy().Spec.Ingress[1]
-			anp.Spec.Ingress[1] = allowRule
-			err = s.Client.Update(ctx, anp)
-			require.NoErrorf(t, err, "unable to update the admin network policy")
+			allowRule := mutate.Spec.Ingress[0]
+			mutate.Spec.Ingress[0] = mutate.Spec.Ingress[1]
+			mutate.Spec.Ingress[1] = allowRule
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(anp))
+			require.NoErrorf(t, err, "unable to patch the admin network policy")
 			// luna-lovegood-0 is our client pod in ravenclaw namespace
 			// ensure ingress is DENIED from ravenclaw to gryffindor
 			// ingressRule at index0 will take precedence over ingressRule at index1; thus DENY takes precedence over ALLOW since rules are ordered
@@ -163,12 +164,13 @@ var AdminNetworkPolicyIngressTCP = suite.ConformanceTest{
 				Name: "ingress-tcp",
 			}, anp)
 			require.NoErrorf(t, err, "unable to fetch the admin network policy")
+			mutate := anp.DeepCopy()
 			// swap rules at index0 and index2
-			denyRule := anp.DeepCopy().Spec.Ingress[0]
-			anp.Spec.Ingress[0] = anp.DeepCopy().Spec.Ingress[2]
-			anp.Spec.Ingress[2] = denyRule
-			err = s.Client.Update(ctx, anp)
-			require.NoErrorf(t, err, "unable to update the admin network policy")
+			denyRule := mutate.Spec.Ingress[0]
+			mutate.Spec.Ingress[0] = mutate.Spec.Ingress[2]
+			mutate.Spec.Ingress[2] = denyRule
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(anp))
+			require.NoErrorf(t, err, "unable to patch the admin network policy")
 			// luna-lovegood-0 is our client pod in ravenclaw namespace
 			// ensure ingress is PASSED from ravenclaw to gryffindor
 			// ingressRule at index0 will take precedence over ingressRule at index1&index2; thus PASS takes precedence over ALLOW/DENY since rules are ordered
@@ -197,12 +199,13 @@ var AdminNetworkPolicyIngressTCP = suite.ConformanceTest{
 				Name: "ingress-tcp",
 			}, anp)
 			require.NoErrorf(t, err, "unable to fetch the admin network policy")
+			mutate := anp.DeepCopy()
 			// swap rules at index3 and index4
-			denyRule := anp.DeepCopy().Spec.Ingress[3]
-			anp.Spec.Ingress[3] = anp.DeepCopy().Spec.Ingress[4]
-			anp.Spec.Ingress[4] = denyRule
-			err = s.Client.Update(ctx, anp)
-			require.NoErrorf(t, err, "unable to update the admin network policy")
+			denyRule := mutate.Spec.Ingress[3]
+			mutate.Spec.Ingress[3] = mutate.Spec.Ingress[4]
+			mutate.Spec.Ingress[4] = denyRule
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(anp))
+			require.NoErrorf(t, err, "unable to patch the admin network policy")
 			// draco-malfoy-0 is our client pod in slytherin namespace
 			// ensure ingress from slytherin is PASSED to gryffindor at port 9003; ingressRule at index3 should take effect
 			success := kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-slytherin", "draco-malfoy-0", "tcp",

--- a/conformance/tests/admin-network-policy-core-ingress-udp-rules.go
+++ b/conformance/tests/admin-network-policy-core-ingress-udp-rules.go
@@ -107,12 +107,13 @@ var AdminNetworkPolicyIngressUDP = suite.ConformanceTest{
 				Name: "ingress-udp",
 			}, anp)
 			require.NoErrorf(t, err, "unable to fetch the admin network policy")
+			mutate := anp.DeepCopy()
 			// swap rules at index0 and index1
-			allowRule := anp.DeepCopy().Spec.Ingress[0]
-			anp.Spec.Ingress[0] = anp.DeepCopy().Spec.Ingress[1]
-			anp.Spec.Ingress[1] = allowRule
-			err = s.Client.Update(ctx, anp)
-			require.NoErrorf(t, err, "unable to update the admin network policy")
+			allowRule := mutate.Spec.Ingress[0]
+			mutate.Spec.Ingress[0] = mutate.Spec.Ingress[1]
+			mutate.Spec.Ingress[1] = allowRule
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(anp))
+			require.NoErrorf(t, err, "unable to patch the admin network policy")
 			// luna-lovegood-0 is our client pod in ravenclaw namespace
 			// ensure ingress is DENIED from ravenclaw to hufflepuff
 			// ingressRule at index0 will take precedence over ingressRule at index1; thus DENY takes precedence over ALLOW since rules are ordered
@@ -164,12 +165,13 @@ var AdminNetworkPolicyIngressUDP = suite.ConformanceTest{
 				Name: "ingress-udp",
 			}, anp)
 			require.NoErrorf(t, err, "unable to fetch the admin network policy")
+			mutate := anp.DeepCopy()
 			// swap rules at index0 and index2
-			denyRule := anp.DeepCopy().Spec.Ingress[0]
-			anp.Spec.Ingress[0] = anp.DeepCopy().Spec.Ingress[2]
-			anp.Spec.Ingress[2] = denyRule
-			err = s.Client.Update(ctx, anp)
-			require.NoErrorf(t, err, "unable to update the admin network policy")
+			denyRule := mutate.Spec.Ingress[0]
+			mutate.Spec.Ingress[0] = mutate.Spec.Ingress[2]
+			mutate.Spec.Ingress[2] = denyRule
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(anp))
+			require.NoErrorf(t, err, "unable to patch the admin network policy")
 			// luna-lovegood-0 is our client pod in ravenclaw namespace
 			// ensure ingress is PASSED from ravenclaw to hufflepuff
 			// ingressRule at index0 will take precedence over ingressRule at index1&index2; thus PASS takes precedence over ALLOW/DENY since rules are ordered
@@ -198,12 +200,13 @@ var AdminNetworkPolicyIngressUDP = suite.ConformanceTest{
 				Name: "ingress-udp",
 			}, anp)
 			require.NoErrorf(t, err, "unable to fetch the admin network policy")
+			mutate := anp.DeepCopy()
 			// swap rules at index3 and index4
-			denyRule := anp.DeepCopy().Spec.Ingress[3]
-			anp.Spec.Ingress[3] = anp.DeepCopy().Spec.Ingress[4]
-			anp.Spec.Ingress[4] = denyRule
-			err = s.Client.Update(ctx, anp)
-			require.NoErrorf(t, err, "unable to update the admin network policy")
+			denyRule := mutate.Spec.Ingress[3]
+			mutate.Spec.Ingress[3] = mutate.Spec.Ingress[4]
+			mutate.Spec.Ingress[4] = denyRule
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(anp))
+			require.NoErrorf(t, err, "unable to patch the admin network policy")
 			// draco-malfoy-0 is our client pod in slytherin namespace
 			// ensure ingress from slytherin is PASSED to hufflepuff at port 5353; ingressRule at index3 should take effect
 			success := kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-slytherin", "draco-malfoy-0", "udp",

--- a/conformance/tests/admin-network-policy-core-integration.go
+++ b/conformance/tests/admin-network-policy-core-integration.go
@@ -103,10 +103,11 @@ var AdminNetworkPolicyIntegration = suite.ConformanceTest{
 				Name: "pass-example",
 			}, anp)
 			require.NoErrorf(t, err, "unable to fetch the admin network policy")
+			mutate := anp.DeepCopy()
 			// change ingress rule from "deny" to "pass"
-			anp.Spec.Ingress[0].Action = v1alpha1.AdminNetworkPolicyRuleActionPass
-			err = s.Client.Update(ctx, anp)
-			require.NoErrorf(t, err, "unable to update the admin network policy")
+			mutate.Spec.Ingress[0].Action = v1alpha1.AdminNetworkPolicyRuleActionPass
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(anp))
+			require.NoErrorf(t, err, "unable to patch the admin network policy")
 			// harry-potter-0 is our server pod in gryffindor namespace
 			serverPod := &v1.Pod{}
 			err = s.Client.Get(ctx, client.ObjectKey{
@@ -136,10 +137,11 @@ var AdminNetworkPolicyIntegration = suite.ConformanceTest{
 				Name: "pass-example",
 			}, anp)
 			require.NoErrorf(t, err, "unable to fetch the admin network policy")
+			mutate := anp.DeepCopy()
 			// change egress rule from "deny" to "pass"
-			anp.Spec.Egress[0].Action = v1alpha1.AdminNetworkPolicyRuleActionPass
-			err = s.Client.Update(ctx, anp)
-			require.NoErrorf(t, err, "unable to update the admin network policy")
+			mutate.Spec.Egress[0].Action = v1alpha1.AdminNetworkPolicyRuleActionPass
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(anp))
+			require.NoErrorf(t, err, "unable to patch the admin network policy")
 			// draco-malfoy-0 is our server pod in slytherin namespace
 			serverPod := &v1.Pod{}
 			err = s.Client.Get(ctx, client.ObjectKey{

--- a/conformance/tests/admin-network-policy-core-priority.go
+++ b/conformance/tests/admin-network-policy-core-priority.go
@@ -101,10 +101,11 @@ var AdminNetworkPolicyPriorityField = suite.ConformanceTest{
 				Name: "old-priority-60-new-priority-40-example",
 			}, anp)
 			require.NoErrorf(t, err, "unable to fetch the admin network policy")
+			mutate := anp.DeepCopy()
 			// change priority from 60 to 40
-			anp.Spec.Priority = 40
-			err = s.Client.Update(ctx, anp)
-			require.NoErrorf(t, err, "unable to update the admin network policy")
+			mutate.Spec.Priority = 40
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(anp))
+			require.NoErrorf(t, err, "unable to patch the admin network policy")
 			// harry-potter-0 is our server pod in gryffindor namespace
 			serverPod := &v1.Pod{}
 			err = s.Client.Get(ctx, client.ObjectKey{

--- a/conformance/tests/admin-network-policy-extended-egress-rules.go
+++ b/conformance/tests/admin-network-policy-extended-egress-rules.go
@@ -65,7 +65,8 @@ var AdminNetworkPolicyEgressNamedPort = suite.ConformanceTest{
 				Name: "egress-tcp",
 			}, anp)
 			require.NoErrorf(t, err, "unable to fetch the admin network policy")
-			namedPortRule := anp.DeepCopy().Spec.Egress[5]
+			mutate := anp.DeepCopy()
+			namedPortRule := mutate.Spec.Egress[5]
 			webPort := "web"
 			// replace the tcp port 8080 rule as named port rule which translate to tcp port 80 instead
 			namedPortRule.Ports = &[]v1alpha1.AdminNetworkPolicyPort{
@@ -73,9 +74,9 @@ var AdminNetworkPolicyEgressNamedPort = suite.ConformanceTest{
 					NamedPort: &webPort,
 				},
 			}
-			anp.Spec.Egress[5] = namedPortRule
-			err = s.Client.Update(ctx, anp)
-			require.NoErrorf(t, err, "unable to update the admin network policy")
+			mutate.Spec.Egress[5] = namedPortRule
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(anp))
+			require.NoErrorf(t, err, "unable to patch the admin network policy")
 			// harry-potter-0 is our client pod in gryffindor namespace
 			// ensure egress is ALLOWED to hufflepuff from gryffindor at the web port, which is defined as TCP at port 80 in pod spec
 			// egressRule at index5 should take effect
@@ -219,6 +220,7 @@ var AdminNetworkPolicyEgressInlineCIDRPeers = suite.ConformanceTest{
 				Name: "node-and-cidr-as-peers-example",
 			}, anp)
 			require.NoErrorf(t, err, "unable to fetch the admin network policy")
+			mutate := anp.DeepCopy()
 			var mask string
 			if net.IsIPv4String(serverPodRavenclaw.Status.PodIP) {
 				mask = "/32"
@@ -240,9 +242,9 @@ var AdminNetworkPolicyEgressInlineCIDRPeers = suite.ConformanceTest{
 					},
 				},
 			}
-			anp.Spec.Egress = append(newRule, anp.DeepCopy().Spec.Egress...)
-			err = s.Client.Update(ctx, anp)
-			require.NoErrorf(t, err, "unable to update the admin network policy")
+			mutate.Spec.Egress = append(newRule, mutate.Spec.Egress...)
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(anp))
+			require.NoErrorf(t, err, "unable to patch the admin network policy")
 			// harry-potter-0 is our client pod in gryffindor namespace
 			// ensure egress is ALLOWED to luna-lovegood-0.IP and cedric-diggory-0.IP
 			// new egressRule at index0 should take effect

--- a/conformance/tests/admin-network-policy-extended-ingress-rules.go
+++ b/conformance/tests/admin-network-policy-extended-ingress-rules.go
@@ -56,7 +56,8 @@ var AdminNetworkPolicyIngressNamedPort = suite.ConformanceTest{
 				Name: "ingress-udp",
 			}, anp)
 			require.NoErrorf(t, err, "unable to fetch the admin network policy")
-			dnsPortRule := anp.DeepCopy().Spec.Ingress[5]
+			mutate := anp.DeepCopy()
+			dnsPortRule := mutate.DeepCopy().Spec.Ingress[5]
 			dnsPort := "dns"
 			// rewrite the udp port 53 rule as named port rule
 			dnsPortRule.Ports = &[]v1alpha1.AdminNetworkPolicyPort{
@@ -64,9 +65,9 @@ var AdminNetworkPolicyIngressNamedPort = suite.ConformanceTest{
 					NamedPort: &dnsPort,
 				},
 			}
-			anp.Spec.Ingress[5] = dnsPortRule
-			err = s.Client.Update(ctx, anp)
-			require.NoErrorf(t, err, "unable to update the admin network policy")
+			mutate.Spec.Ingress[5] = dnsPortRule
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(anp))
+			require.NoErrorf(t, err, "unable to patch the admin network policy")
 			// harry-potter-0 is our client pod in gryffindor namespace
 			// ensure ingress is ALLOWED from gryffindor to hufflepuff at the dns port, which is defined as UDP at port 53 in pod spec
 			// modified ingressRule at index5 should take effect

--- a/conformance/tests/baseline-admin-network-policy-core-egress-sctp-rules.go
+++ b/conformance/tests/baseline-admin-network-policy-core-egress-sctp-rules.go
@@ -107,12 +107,13 @@ var BaselineAdminNetworkPolicyEgressSCTP = suite.ConformanceTest{
 				Name: "default",
 			}, banp)
 			require.NoErrorf(t, err, "unable to fetch the baseline admin network policy")
+			mutate := banp.DeepCopy()
 			// swap rules at index0 and index1
-			allowRule := banp.DeepCopy().Spec.Egress[0]
-			banp.Spec.Egress[0] = banp.DeepCopy().Spec.Egress[1]
-			banp.Spec.Egress[1] = allowRule
-			err = s.Client.Update(ctx, banp)
-			require.NoErrorf(t, err, "unable to update the baseline admin network policy")
+			allowRule := mutate.Spec.Egress[0]
+			mutate.Spec.Egress[0] = mutate.Spec.Egress[1]
+			mutate.Spec.Egress[1] = allowRule
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(banp))
+			require.NoErrorf(t, err, "unable to patch the baseline admin network policy")
 			// luna-lovegood-0 is our client pod in gryffindor namespace
 			// ensure egress is DENIED to gryffindor from ravenclaw
 			// egressRule at index0 will take precedence over egressRule at index1; thus DENY takes precedence over ALLOW since rules are ordered

--- a/conformance/tests/baseline-admin-network-policy-core-egress-tcp-rules.go
+++ b/conformance/tests/baseline-admin-network-policy-core-egress-tcp-rules.go
@@ -106,12 +106,13 @@ var BaselineAdminNetworkPolicyEgressTCP = suite.ConformanceTest{
 				Name: "default",
 			}, banp)
 			require.NoErrorf(t, err, "unable to fetch the baseline admin network policy")
+			mutate := banp.DeepCopy()
 			// swap rules at index0 and index1
-			allowRule := banp.DeepCopy().Spec.Egress[0]
-			banp.Spec.Egress[0] = banp.DeepCopy().Spec.Egress[1]
-			banp.Spec.Egress[1] = allowRule
-			err = s.Client.Update(ctx, banp)
-			require.NoErrorf(t, err, "unable to update the baseline admin network policy")
+			allowRule := mutate.Spec.Egress[0]
+			mutate.Spec.Egress[0] = mutate.Spec.Egress[1]
+			mutate.Spec.Egress[1] = allowRule
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(banp))
+			require.NoErrorf(t, err, "unable to patch the baseline admin network policy")
 			// harry-potter-0 is our client pod in gryffindor namespace
 			// ensure egress is DENIED to ravenclaw from gryffindor
 			// egressRule at index0 will take precedence over egressRule at index1; thus DENY takes precedence over ALLOW since rules are ordered

--- a/conformance/tests/baseline-admin-network-policy-core-egress-udp-rules.go
+++ b/conformance/tests/baseline-admin-network-policy-core-egress-udp-rules.go
@@ -107,12 +107,13 @@ var BaselineAdminNetworkPolicyEgressUDP = suite.ConformanceTest{
 				Name: "default",
 			}, banp)
 			require.NoErrorf(t, err, "unable to fetch the baseline admin network policy")
+			mutate := banp.DeepCopy()
 			// swap rules at index0 and index1
-			allowRule := banp.DeepCopy().Spec.Egress[0]
-			banp.Spec.Egress[0] = banp.DeepCopy().Spec.Egress[1]
-			banp.Spec.Egress[1] = allowRule
-			err = s.Client.Update(ctx, banp)
-			require.NoErrorf(t, err, "unable to update the baseline admin network policy")
+			allowRule := mutate.Spec.Egress[0]
+			mutate.Spec.Egress[0] = mutate.Spec.Egress[1]
+			mutate.Spec.Egress[1] = allowRule
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(banp))
+			require.NoErrorf(t, err, "unable to patch the baseline admin network policy")
 			// cedric-diggory-0 is our client pod in hufflepuff namespace
 			// ensure egress is DENIED to ravenclaw to hufflepuff
 			// egressRule at index0 will take precedence over egressRule at index1; thus DENY takes precedence over ALLOW since rules are ordered

--- a/conformance/tests/baseline-admin-network-policy-core-gress-rules.go
+++ b/conformance/tests/baseline-admin-network-policy-core-gress-rules.go
@@ -193,15 +193,16 @@ var BaselineAdminNetworkPolicyGress = suite.ConformanceTest{
 				Name: "default",
 			}, banp)
 			require.NoErrorf(t, err, "unable to fetch the baseline admin network policy")
+			mutate := banp.DeepCopy()
 			// swap rules at index0 and index1 for both ingress and egress
-			allowOutRule := banp.DeepCopy().Spec.Egress[0]
-			banp.Spec.Egress[0] = banp.DeepCopy().Spec.Egress[1]
-			banp.Spec.Egress[1] = allowOutRule
-			allowInRule := banp.DeepCopy().Spec.Ingress[0]
-			banp.Spec.Ingress[0] = banp.DeepCopy().Spec.Ingress[1]
-			banp.Spec.Ingress[1] = allowInRule
-			err = s.Client.Update(ctx, banp)
-			require.NoErrorf(t, err, "unable to update the baseline admin network policy")
+			allowOutRule := mutate.Spec.Egress[0]
+			mutate.Spec.Egress[0] = mutate.Spec.Egress[1]
+			mutate.Spec.Egress[1] = allowOutRule
+			allowInRule := mutate.Spec.Ingress[0]
+			mutate.Spec.Ingress[0] = mutate.Spec.Ingress[1]
+			mutate.Spec.Ingress[1] = allowInRule
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(banp))
+			require.NoErrorf(t, err, "unable to patch the baseline admin network policy")
 			// harry-potter-x is our client pod in gryffindor namespace
 			// ensure egress is DENIED to ravenclaw from gryffindor
 			// egressRule at index0 will take precedence over egressRule at index1; thus DENY takes precedence over ALLOW since rules are ordered

--- a/conformance/tests/baseline-admin-network-policy-core-ingress-sctp-rules.go
+++ b/conformance/tests/baseline-admin-network-policy-core-ingress-sctp-rules.go
@@ -106,12 +106,13 @@ var BaselineAdminNetworkPolicyIngressSCTP = suite.ConformanceTest{
 				Name: "default",
 			}, banp)
 			require.NoErrorf(t, err, "unable to fetch the baseline admin network policy")
+			mutate := banp.DeepCopy()
 			// swap rules at index0 and index1
-			allowRule := banp.DeepCopy().Spec.Ingress[0]
-			banp.Spec.Ingress[0] = banp.DeepCopy().Spec.Ingress[1]
-			banp.Spec.Ingress[1] = allowRule
-			err = s.Client.Update(ctx, banp)
-			require.NoErrorf(t, err, "unable to update the baseline admin network policy")
+			allowRule := mutate.Spec.Ingress[0]
+			mutate.Spec.Ingress[0] = mutate.Spec.Ingress[1]
+			mutate.Spec.Ingress[1] = allowRule
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(banp))
+			require.NoErrorf(t, err, "unable to patch the baseline admin network policy")
 			// harry-potter-0 is our client pod in gryffindor namespace
 			// ensure ingress is DENIED from gryffindor to ravenclaw
 			// ingressRule at index0 will take precedence over ingressRule at index1; thus DENY takes precedence over ALLOW since rules are ordered

--- a/conformance/tests/baseline-admin-network-policy-core-ingress-tcp-rules.go
+++ b/conformance/tests/baseline-admin-network-policy-core-ingress-tcp-rules.go
@@ -106,12 +106,13 @@ var BaselineAdminNetworkPolicyIngressTCP = suite.ConformanceTest{
 				Name: "default",
 			}, banp)
 			require.NoErrorf(t, err, "unable to fetch the baseline admin network policy")
+			mutate := banp.DeepCopy()
 			// swap rules at index0 and index1
-			allowRule := banp.DeepCopy().Spec.Ingress[0]
-			banp.Spec.Ingress[0] = banp.DeepCopy().Spec.Ingress[1]
-			banp.Spec.Ingress[1] = allowRule
-			err = s.Client.Update(ctx, banp)
-			require.NoErrorf(t, err, "unable to update the baseline admin network policy")
+			allowRule := mutate.Spec.Ingress[0]
+			mutate.Spec.Ingress[0] = mutate.Spec.Ingress[1]
+			mutate.Spec.Ingress[1] = allowRule
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(banp))
+			require.NoErrorf(t, err, "unable to patch the baseline admin network policy")
 			// luna-lovegood-0 is our client pod in ravenclaw namespace
 			// ensure ingress is DENIED from ravenclaw to gryffindor
 			// ingressRule at index0 will take precedence over ingressRule at index1; thus DENY takes precedence over ALLOW since rules are ordered

--- a/conformance/tests/baseline-admin-network-policy-core-ingress-udp-rules.go
+++ b/conformance/tests/baseline-admin-network-policy-core-ingress-udp-rules.go
@@ -106,12 +106,13 @@ var BaselineAdminNetworkPolicyIngressUDP = suite.ConformanceTest{
 				Name: "default",
 			}, banp)
 			require.NoErrorf(t, err, "unable to fetch the admin network policy")
+			mutate := banp.DeepCopy()
 			// swap rules at index0 and index1
-			allowRule := banp.DeepCopy().Spec.Ingress[0]
-			banp.Spec.Ingress[0] = banp.DeepCopy().Spec.Ingress[1]
-			banp.Spec.Ingress[1] = allowRule
-			err = s.Client.Update(ctx, banp)
-			require.NoErrorf(t, err, "unable to update the admin network policy")
+			allowRule := mutate.Spec.Ingress[0]
+			mutate.Spec.Ingress[0] = mutate.Spec.Ingress[1]
+			mutate.Spec.Ingress[1] = allowRule
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(banp))
+			require.NoErrorf(t, err, "unable to patch the baseline admin network policy")
 			// luna-lovegood-0 is our client pod in ravenclaw namespace
 			// ensure ingress is DENIED from ravenclaw to hufflepuff
 			// ingressRule at index0 will take precedence over ingressRule at index1; thus DENY takes precedence over ALLOW since rules are ordered

--- a/conformance/tests/baseline-admin-network-policy-extended-egress-rules.go
+++ b/conformance/tests/baseline-admin-network-policy-extended-egress-rules.go
@@ -65,7 +65,8 @@ var BaselineAdminNetworkPolicyEgressNamedPort = suite.ConformanceTest{
 				Name: "default",
 			}, banp)
 			require.NoErrorf(t, err, "unable to fetch the baseline admin network policy")
-			dnsPortRule := banp.DeepCopy().Spec.Egress[3]
+			mutate := banp.DeepCopy()
+			dnsPortRule := mutate.Spec.Egress[3]
 			dnsPort := "dns"
 			// rewrite the udp port 53 rule as named port rule
 			dnsPortRule.Ports = &[]v1alpha1.AdminNetworkPolicyPort{
@@ -73,9 +74,9 @@ var BaselineAdminNetworkPolicyEgressNamedPort = suite.ConformanceTest{
 					NamedPort: &dnsPort,
 				},
 			}
-			banp.Spec.Egress[3] = dnsPortRule
-			err = s.Client.Update(ctx, banp)
-			require.NoErrorf(t, err, "unable to update the baseline admin network policy")
+			mutate.Spec.Egress[3] = dnsPortRule
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(banp))
+			require.NoErrorf(t, err, "unable to patch the baseline admin network policy")
 			// cedric-diggory-0 is our client pod in hufflepuff namespace
 			// ensure egress is ALLOWED to gryffindor from hufflepuff at the dns port, which is defined as UDP at port 53 in pod spec
 			// modified ingressRule at index3 should take effect
@@ -209,6 +210,7 @@ var BaselineAdminNetworkPolicyEgressInlineCIDRPeers = suite.ConformanceTest{
 				Name: "default",
 			}, banp)
 			require.NoErrorf(t, err, "unable to fetch the baseline admin network policy")
+			mutate := banp.DeepCopy()
 			var mask string
 			if net.IsIPv4String(serverPodRavenclaw.Status.PodIP) {
 				mask = "/32"
@@ -230,9 +232,9 @@ var BaselineAdminNetworkPolicyEgressInlineCIDRPeers = suite.ConformanceTest{
 					},
 				},
 			}
-			banp.Spec.Egress = append(newRule, banp.DeepCopy().Spec.Egress...)
-			err = s.Client.Update(ctx, banp)
-			require.NoErrorf(t, err, "unable to update the baseline admin network policy")
+			mutate.Spec.Egress = append(newRule, mutate.Spec.Egress...)
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(banp))
+			require.NoErrorf(t, err, "unable to patch the baseline admin network policy")
 			// harry-potter-0 is our client pod in gryffindor namespace
 			// ensure egress is ALLOWED to luna-lovegood-0.IP and cedric-diggory-0.IP
 			// new egressRule at index0 should take effect

--- a/conformance/tests/baseline-admin-network-policy-extended-ingress-rules.go
+++ b/conformance/tests/baseline-admin-network-policy-extended-ingress-rules.go
@@ -62,7 +62,8 @@ var BaselineAdminNetworkPolicyIngressNamedPort = suite.ConformanceTest{
 				Name: "default",
 			}, banp)
 			require.NoErrorf(t, err, "unable to fetch the baseline admin network policy")
-			namedPortRule := banp.DeepCopy().Spec.Ingress[3]
+			mutate := banp.DeepCopy()
+			namedPortRule := mutate.Spec.Ingress[3]
 			webPort := "web"
 			// rewrite the tcp port 80 rule as named port rule
 			namedPortRule.Ports = &[]v1alpha1.AdminNetworkPolicyPort{
@@ -70,9 +71,9 @@ var BaselineAdminNetworkPolicyIngressNamedPort = suite.ConformanceTest{
 					NamedPort: &webPort,
 				},
 			}
-			banp.Spec.Ingress[3] = namedPortRule
-			err = s.Client.Update(ctx, banp)
-			require.NoErrorf(t, err, "unable to update the baseline admin network policy")
+			mutate.Spec.Ingress[3] = namedPortRule
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(banp))
+			require.NoErrorf(t, err, "unable to patch the baseline admin network policy")
 			// cedric-diggory-0 is our client pod in hufflepuff namespace
 			// ensure ingress is ALLOWED from hufflepuff to gryffindor at at the web port, which is defined as TCP at port 80 in pod spec
 			// ingressRule at index3 should take effect


### PR DESCRIPTION
We are hitting a conformance test bug:

```
=== RUN   TestNetworkPolicyV2Conformance/AdminNetworkPolicyEgressNamedPort#01/Should_support_an_'allow-egress'_policy_for_named_port
2024-04-08T00:12:49.3743969Z     admin-network-policy-extended-egress-rules.go:78:
2024-04-08T00:12:49.3746768Z         	Error Trace:	/home/runner/go/pkg/mod/sigs.k8s.io/network-policy-api@v0.1.3-0.20240311165859-d48faeeb0e02/conformance/tests/admin-network-policy-extended-egress-rules.go:78
2024-04-08T00:12:49.3748756Z         	Error:      	Received unexpected error:
2024-04-08T00:12:49.3752415Z         	            	Operation cannot be fulfilled on adminnetworkpolicies.policy.networking.k8s.io "egress-tcp": the object has been modified; please apply your changes to the latest version and try again
2024-04-08T00:12:49.3756029Z         	Test:       	TestNetworkPolicyV2Conformance/AdminNetworkPolicyEgressNamedPort#01/Should_support_an_'allow-egress'_policy_for_named_port
2024-04-08T00:12:49.3757297Z         	Messages:   	unable to update the admin network policy
```

that happens because resource version changes for the resource, let's use patch in our conformance tests instead of updates.