### PR TITLE
Ensure we clarify subjects don't include host-net pods

### DIFF
--- a/apis/v1alpha1/adminnetworkpolicy_types.go
+++ b/apis/v1alpha1/adminnetworkpolicy_types.go
@@ -69,6 +69,7 @@ type AdminNetworkPolicySpec struct {
 	Priority int32 `json:"priority"`
 
 	// Subject defines the pods to which this AdminNetworkPolicy applies.
+	// Note that host-networked pods are not included in subject selection.
 	//
 	// Support: Core
 	//

--- a/apis/v1alpha1/baselineadminnetworkpolicy_types.go
+++ b/apis/v1alpha1/baselineadminnetworkpolicy_types.go
@@ -55,6 +55,7 @@ type BaselineAdminNetworkPolicyStatus struct {
 // BaselineAdminNetworkPolicy.
 type BaselineAdminNetworkPolicySpec struct {
 	// Subject defines the pods to which this BaselineAdminNetworkPolicy applies.
+	// Note that host-networked pods are not included in subject selection.
 	//
 	// Support: Core
 	//

--- a/config/crd/experimental/policy.networking.k8s.io_adminnetworkpolicies.yaml
+++ b/config/crd/experimental/policy.networking.k8s.io_adminnetworkpolicies.yaml
@@ -832,6 +832,7 @@ spec:
               subject:
                 description: |-
                   Subject defines the pods to which this AdminNetworkPolicy applies.
+                  Note that host-networked pods are not included in subject selection.
 
 
                   Support: Core

--- a/config/crd/experimental/policy.networking.k8s.io_baselineadminnetworkpolicies.yaml
+++ b/config/crd/experimental/policy.networking.k8s.io_baselineadminnetworkpolicies.yaml
@@ -804,6 +804,7 @@ spec:
               subject:
                 description: |-
                   Subject defines the pods to which this BaselineAdminNetworkPolicy applies.
+                  Note that host-networked pods are not included in subject selection.
 
 
                   Support: Core

--- a/config/crd/standard/policy.networking.k8s.io_adminnetworkpolicies.yaml
+++ b/config/crd/standard/policy.networking.k8s.io_adminnetworkpolicies.yaml
@@ -716,6 +716,7 @@ spec:
               subject:
                 description: |-
                   Subject defines the pods to which this AdminNetworkPolicy applies.
+                  Note that host-networked pods are not included in subject selection.
 
 
                   Support: Core

--- a/config/crd/standard/policy.networking.k8s.io_baselineadminnetworkpolicies.yaml
+++ b/config/crd/standard/policy.networking.k8s.io_baselineadminnetworkpolicies.yaml
@@ -688,6 +688,7 @@ spec:
               subject:
                 description: |-
                   Subject defines the pods to which this BaselineAdminNetworkPolicy applies.
+                  Note that host-networked pods are not included in subject selection.
 
 
                   Support: Core


### PR DESCRIPTION
PR enhances the subject description to call out the fact that subjects don't include host-net "pods"