### PR TITLE
Update the text about duplicate priority values

### DIFF
--- a/apis/v1alpha1/adminnetworkpolicy_types.go
+++ b/apis/v1alpha1/adminnetworkpolicy_types.go
@@ -56,11 +56,14 @@ type AdminNetworkPolicyStatus struct {
 
 // AdminNetworkPolicySpec defines the desired state of AdminNetworkPolicy.
 type AdminNetworkPolicySpec struct {
-	// Priority is a value from 0 to 1000. Rules with lower priority values have
-	// higher precedence, and are checked before rules with higher priority values.
+	// Priority is a value from 0 to 1000. Policies with lower priority values have
+	// higher precedence, and are checked before policies with higher priority values.
 	// All AdminNetworkPolicy rules have higher precedence than NetworkPolicy or
 	// BaselineAdminNetworkPolicy rules
-	// The behavior is undefined if two ANP objects have same priority.
+	// Every AdminNetworkPolicy should have a unique priority value; if two (or more)
+	// policies with the same priority could both match a connection, then the
+	// implementation can apply any of the matching policies to the connection, and
+	// there is no way for the user to reliably determine which one it will choose.
 	//
 	// Support: Core
 	//

--- a/config/crd/experimental/policy.networking.k8s.io_adminnetworkpolicies.yaml
+++ b/config/crd/experimental/policy.networking.k8s.io_adminnetworkpolicies.yaml
@@ -817,11 +817,14 @@ spec:
                 type: array
               priority:
                 description: |-
-                  Priority is a value from 0 to 1000. Rules with lower priority values have
-                  higher precedence, and are checked before rules with higher priority values.
+                  Priority is a value from 0 to 1000. Policies with lower priority values have
+                  higher precedence, and are checked before policies with higher priority values.
                   All AdminNetworkPolicy rules have higher precedence than NetworkPolicy or
                   BaselineAdminNetworkPolicy rules
-                  The behavior is undefined if two ANP objects have same priority.
+                  Every AdminNetworkPolicy should have a unique priority value; if two (or more)
+                  policies with the same priority could both match a connection, then the
+                  implementation can apply any of the matching policies to the connection, and
+                  there is no way for the user to reliably determine which one it will choose.
 
 
                   Support: Core

--- a/config/crd/standard/policy.networking.k8s.io_adminnetworkpolicies.yaml
+++ b/config/crd/standard/policy.networking.k8s.io_adminnetworkpolicies.yaml
@@ -701,11 +701,14 @@ spec:
                 type: array
               priority:
                 description: |-
-                  Priority is a value from 0 to 1000. Rules with lower priority values have
-                  higher precedence, and are checked before rules with higher priority values.
+                  Priority is a value from 0 to 1000. Policies with lower priority values have
+                  higher precedence, and are checked before policies with higher priority values.
                   All AdminNetworkPolicy rules have higher precedence than NetworkPolicy or
                   BaselineAdminNetworkPolicy rules
-                  The behavior is undefined if two ANP objects have same priority.
+                  Every AdminNetworkPolicy should have a unique priority value; if two (or more)
+                  policies with the same priority could both match a connection, then the
+                  implementation can apply any of the matching policies to the connection, and
+                  there is no way for the user to reliably determine which one it will choose.
 
 
                   Support: Core


### PR DESCRIPTION
Clarify the limits of the undefined behavior when two policies have the same priority.

Fixes #216

/cc @astoycos @tssurya @npinaeva @fasaxc @nathanjsweet @aojea