### PR TITLE
[Policy Assistant] display enhancements

### DIFF
--- a/cmd/policy-assistant/pkg/connectivity/probe/connectivity.go
+++ b/cmd/policy-assistant/pkg/connectivity/probe/connectivity.go
@@ -11,6 +11,8 @@ const (
 	ConnectivityInvalidPortProtocol Connectivity = "invalidportprotocol"
 	ConnectivityBlocked             Connectivity = "blocked"
 	ConnectivityAllowed             Connectivity = "allowed"
+	// ConnectivityUndefined e.g. for loopback traffic
+	ConnectivityUndefined Connectivity = "undefined"
 )
 
 var AllConnectivity = []Connectivity{
@@ -36,6 +38,8 @@ func (p Connectivity) ShortString() string {
 		return "P"
 	case ConnectivityInvalidPortProtocol:
 		return "N"
+	case ConnectivityUndefined:
+		return "#"
 	default:
 		panic(errors.Errorf("invalid Connectivity value: %+v", p))
 	}

--- a/cmd/policy-assistant/pkg/connectivity/probe/jobrunner.go
+++ b/cmd/policy-assistant/pkg/connectivity/probe/jobrunner.go
@@ -76,6 +76,11 @@ func (s *SimulatedJobRunner) RunJobs(jobs []*Job) []*JobResult {
 }
 
 func (s *SimulatedJobRunner) RunJob(job *Job) *JobResult {
+	if job.FromKey == job.ToKey {
+		connUndefined := ConnectivityUndefined
+		return &JobResult{Job: job, Ingress: &connUndefined, Egress: &connUndefined, Combined: ConnectivityUndefined}
+	}
+
 	allowed := s.Policies.IsTrafficAllowed(job.Traffic())
 	// TODO could also keep the whole `allowed` struct somewhere
 

--- a/cmd/policy-assistant/pkg/matcher/explain.go
+++ b/cmd/policy-assistant/pkg/matcher/explain.go
@@ -55,8 +55,10 @@ func (p *Policy) ExplainTable() string {
 	ingresses, egresses := p.SortedTargets()
 	builder.TargetsTableLines(ingresses, true)
 
-	builder.Elements = append(builder.Elements, []string{"", "", "", "", "", ""})
-	builder.TargetsTableLines(egresses, false)
+	if len(egresses) > 0 {
+		builder.Elements = append(builder.Elements, []string{"", "", "", "", "", ""})
+		builder.TargetsTableLines(egresses, false)
+	}
 
 	table.AppendBulk(builder.Elements)
 

--- a/cmd/policy-assistant/pkg/matcher/explain.go
+++ b/cmd/policy-assistant/pkg/matcher/explain.go
@@ -2,11 +2,12 @@ package matcher
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/mattfenwick/collections/pkg/json"
 	"github.com/mattfenwick/collections/pkg/slice"
 	"golang.org/x/exp/slices"
 	v1 "k8s.io/api/core/v1"
-	"strings"
 
 	"github.com/mattfenwick/cyclonus/pkg/kube"
 	"github.com/olekukonko/tablewriter"
@@ -26,7 +27,7 @@ func (p *peerProtocolGroup) Matches(subject, peer *TrafficPeer, portInt int, por
 }
 
 type anpGroup struct {
-	name     string
+	ruleName string
 	priority int
 	effects  []string
 	kind     PolicyKind
@@ -129,9 +130,9 @@ func (s *SliceBuilder) peerProtocolGroupTableLines(t *peerProtocolGroup) {
 		})
 		for _, v := range anps {
 			if len(v.effects) > 1 {
-				actions = append(actions, fmt.Sprintf("   pri=%d (%s): %s (ineffective rules: %s)", v.priority, v.name, v.effects[0], strings.Join(v.effects[1:], ", ")))
+				actions = append(actions, fmt.Sprintf("   pri=%d (%s): %s (ineffective rules: %s)", v.priority, v.ruleName, v.effects[0], strings.Join(v.effects[1:], ", ")))
 			} else {
-				actions = append(actions, fmt.Sprintf("   pri=%d (%s): %s", v.priority, v.name, v.effects[0]))
+				actions = append(actions, fmt.Sprintf("   pri=%d (%s): %s", v.priority, v.ruleName, v.effects[0]))
 			}
 		}
 	}
@@ -199,10 +200,10 @@ func groupAnbAndBanp(p []PeerMatcher) []PeerMatcher {
 					policies: map[string]*anpGroup{},
 				}
 			}
-			kg := t.Name
+			kg := t.PolicyName
 			if _, ok := groups[k].policies[kg]; !ok {
 				groups[k].policies[kg] = &anpGroup{
-					name:     t.Name,
+					ruleName: t.PolicyName,
 					priority: t.effectFromMatch.Priority,
 					effects:  []string{},
 					kind:     t.effectFromMatch.PolicyKind,

--- a/cmd/policy-assistant/pkg/matcher/peermatcherv2.go
+++ b/cmd/policy-assistant/pkg/matcher/peermatcherv2.go
@@ -10,16 +10,19 @@ import (
 // This is because ANP and BANP only deal with Pod to Pod traffic, and do not deal with external IPs.
 type PeerMatcherAdmin struct {
 	*PodPeerMatcher
-	Name            string
+	PolicyName      string
+	RuleName        string
 	effectFromMatch Effect
 }
 
 // NewPeerMatcherANP creates a PeerMatcherAdmin for an ANP rule
-func NewPeerMatcherANP(peer *PodPeerMatcher, v Verdict, priority int, source string) *PeerMatcherAdmin {
+func NewPeerMatcherANP(peer *PodPeerMatcher, v Verdict, priority int, policyName, ruleName string) *PeerMatcherAdmin {
 	return &PeerMatcherAdmin{
 		PodPeerMatcher: peer,
-		Name:           source,
+		PolicyName:     policyName,
+		RuleName:       ruleName,
 		effectFromMatch: Effect{
+			RuleName:   ruleName,
 			PolicyKind: AdminNetworkPolicy,
 			Priority:   priority,
 			Verdict:    v,
@@ -28,11 +31,13 @@ func NewPeerMatcherANP(peer *PodPeerMatcher, v Verdict, priority int, source str
 }
 
 // NewPeerMatcherBANP creates a new PeerMatcherAdmin for a BANP rule
-func NewPeerMatcherBANP(peer *PodPeerMatcher, v Verdict, source string) *PeerMatcherAdmin {
+func NewPeerMatcherBANP(peer *PodPeerMatcher, v Verdict, policyName, ruleName string) *PeerMatcherAdmin {
 	return &PeerMatcherAdmin{
 		PodPeerMatcher: peer,
-		Name:           source,
+		PolicyName:     policyName,
+		RuleName:       ruleName,
 		effectFromMatch: Effect{
+			RuleName:   ruleName,
 			PolicyKind: BaselineAdminNetworkPolicy,
 			Verdict:    v,
 		},
@@ -41,6 +46,7 @@ func NewPeerMatcherBANP(peer *PodPeerMatcher, v Verdict, source string) *PeerMat
 
 // Effect models the effect of one or more v1/v2 NetPol rules on a peer
 type Effect struct {
+	RuleName string
 	PolicyKind
 	// Priority is only used for ANP (there can only be one BANP)
 	Priority int
@@ -57,9 +63,9 @@ const (
 
 func NewV1Effect(allow bool) Effect {
 	if allow {
-		return Effect{NetworkPolicyV1, 0, Allow}
+		return Effect{"", NetworkPolicyV1, 0, Allow}
 	}
-	return Effect{NetworkPolicyV1, 0, None}
+	return Effect{"", NetworkPolicyV1, 0, None}
 }
 
 type Verdict string

--- a/cmd/policy-assistant/pkg/matcher/policy.go
+++ b/cmd/policy-assistant/pkg/matcher/policy.go
@@ -120,15 +120,15 @@ func (d DirectionResult) Flow() string {
 	flows := make([]string, 0)
 	if anp != nil {
 		if anp.Verdict == Allow {
-			return "[ANP] Allow"
+			return fmt.Sprintf("[ANP] Allow (%s)", anp.RuleName)
 		}
 
 		if anp.Verdict == Deny {
-			return "[ANP] Deny"
+			return fmt.Sprintf("[ANP] Deny (%s)", anp.RuleName)
 		}
 
 		if anp.Verdict == Pass {
-			flows = append(flows, "[ANP] Pass")
+			flows = append(flows, fmt.Sprintf("[ANP] Pass (%s)", anp.RuleName))
 		} else {
 			flows = append(flows, "[ANP] No-Op")
 		}
@@ -136,9 +136,9 @@ func (d DirectionResult) Flow() string {
 
 	if npv1 != nil {
 		if npv1.Verdict == Allow {
-			flows = append(flows, "[NPv1] Allow")
+			flows = append(flows, fmt.Sprintf("[NPv1] Allow (%s)", npv1.RuleName))
 		} else {
-			flows = append(flows, "[NPv1] Dropped")
+			flows = append(flows, fmt.Sprintf("[NPv1] Dropped (%s)", npv1.RuleName))
 		}
 
 		return strings.Join(flows, " -> ")
@@ -146,9 +146,9 @@ func (d DirectionResult) Flow() string {
 
 	if banp != nil {
 		if banp.Verdict == Allow {
-			flows = append(flows, "[BANP] Allow")
+			flows = append(flows, fmt.Sprintf("[BANP] Allow (%s)", banp.RuleName))
 		} else if banp.Verdict == Deny {
-			flows = append(flows, "[BANP] Deny")
+			flows = append(flows, fmt.Sprintf("[BANP] Deny (%s)", banp.RuleName))
 		} else {
 			flows = append(flows, "[BANP] No-Op")
 		}


### PR DESCRIPTION
A few enhancements:
1. display (b)anp rule names in the table and "Flow"
2. make connectivity table easier to read for loopback traffic
3. stop adding an extra row in the explain table when there are no egress policy rules

New flow example:
```
[NPv1] Allow (rule-name)
```

Loopback traffic example (adding "#")
```
simulated connectivity:
+--------+--------+--------+
| TCP/80 | DEMO/A | DEMO/B |
| TCP/81 |        |        |
+--------+--------+--------+
| demo/a | # X    | . X    |
+--------+--------+--------+
| demo/b | . X    | # X    |
+--------+--------+--------+
```