### PR TITLE
feat: [Policy Assistant] walkthrough mode and a README (KubeCon demo PR 2/2)

### DIFF
--- a/.github/workflows/policy-assistant.yml
+++ b/.github/workflows/policy-assistant.yml
@@ -90,12 +90,12 @@ jobs:
 
     - name: Run Integration Test - Explain Mode
       run: |
-        artifacts/cyclonus analyze --use-example-policies --mode explain
+        artifacts/cyclonus analyze --mode explain --policy-path cmd/policy-assistant/examples/demos/kubecon-eu-2024/policies/
 
-    # - name: Run Integration Test - Probe Mode
-    #   run: |
-    #     artifacts/cyclonus analyze --use-example-policies --mode probe --probe-path cmd/policy-assistant/examples/demos/kubecon-eu-2024/demo-probe.json
+    - name: Run Integration Test - Probe Mode
+      run: |
+        artifacts/cyclonus analyze --mode probe --policy-path cmd/policy-assistant/examples/demos/kubecon-eu-2024/policies/ --probe-path cmd/policy-assistant/examples/demos/kubecon-eu-2024/demo-probe.json
 
-    # - name: Run Integration Test - Walkthrough Mode
-    #   run: |
-    #     artifacts/cyclonus analyze --use-example-policies --mode walkthrough
+    - name: Run Integration Test - Walkthrough Mode
+      run: |
+        artifacts/cyclonus analyze --mode walkthrough --policy-path cmd/policy-assistant/examples/demos/kubecon-eu-2024/policies/

--- a/cmd/policy-assistant/README.md
+++ b/cmd/policy-assistant/README.md
@@ -1,16 +1,213 @@
 # Policy Assistant (derived from Cyclonus)
 
-Explains your configuration of (Baseline)AdminNetworkPolicy and v1 NetworkPolicy. Additionally, can test conformance of (B)ANP and v1 NetworkPolicy via a connectivity matrix. Derived from the great work of @mattfenwick et al. in [Cyclonus](https://github.com/mattfenwick/cyclonus).
+Policy Assistant is a project to assist users regarding all APIs for network policies.
+Currently, the APIs are:
 
-More details here: [Cyclonus](https://github.com/mattfenwick/cyclonus).
+- [NetworkPolicy (v1)](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
+- [AdminNetworkPolicy and BaselineAdminNetworkPolicy](https://network-policy-api.sigs.k8s.io/api-overview/)
 
-## Usage
+## Overview
 
-CLI currently under development. Will build off of `cyclonus analyze` (visualization) and `cyclonus generate` (conformance tests).
+Policy Assistant is a CLI (command-line interface) designed to help users:
+1. ***Develop/understand policy configurations***.
+1. ***Prevent pitfalls*** while developing policies.
+1. ***Troubleshoot*** network policy issues.
+
+Policy Assistant is a static analysis tool which ***simulates the action of network policies*** for the given traffic. Policy Assistant can read resources either from your cluster or from config files, so no cluster is needed.
+
+For instance, Policy Assistant can simulate and walk through which policies impact cluster traffic:
+
+```shell
+$ pola analyze --namespace demo --mode walkthrough
+verdict walkthrough:
++---------------------------------------+---------+-------------------------------------------------------------+------------------------------+
+|                TRAFFIC                | VERDICT |                     INGRESS WALKTHROUGH                     |      EGRESS WALKTHROUGH      |
++---------------------------------------+---------+-------------------------------------------------------------+------------------------------+
+| demo/[pod=a] -> demo/[pod=b]:80 (TCP) | Allowed | [ANP] Allow (allow-80)                                      | no policies targeting egress |
++---------------------------------------+---------+-------------------------------------------------------------+                              +
+| demo/[pod=a] -> demo/[pod=b]:81 (TCP) | Denied  | [ANP] Pass (pass-81) -> [BANP] Deny (baseline-deny)         |                              |
++---------------------------------------+---------+-------------------------------------------------------------+                              +
+| demo/[pod=b] -> demo/[pod=a]:80 (TCP) | Allowed | [ANP] Allow (allow-80)                                      |                              |
++---------------------------------------+---------+-------------------------------------------------------------+                              +
+| demo/[pod=b] -> demo/[pod=a]:81 (TCP) | Denied  | [ANP] Pass (pass-81) -> [NPv1] Dropped (demo/deny-to-pod-a) |                              |
++---------------------------------------+---------+-------------------------------------------------------------+------------------------------+
+```
+
+### Quick Install
+
+Download the latest `pola` release either from GitHub ([web page](https://github.com/kubernetes-sigs/network-policy-api/releases/v0.0.1-pola)) or via these bash commands:
+
+```bash
+curl -O https://github.com/kubernetes-sigs/network-policy-api/releases/download/v0.0.1-pola/pola_linux_amd64.tar.gz
+# optionally verify check sum
+tar -xvf pola_linux_amd64.tar.gz
+./pola --help
+```
+
+Alternatively, [install from source](#make-from-source).
+
+See [example usage](#example-usage) below.
+
+### Fuzz Testing Capability
+
+CNI developers may benefit from Policy Assistant as well.
+Policy Assistant is capable of providing a fuzz testing framework (see [#154](https://github.com/kubernetes-sigs/network-policy-api/issues/154)) which CNI developers could run as a second conformance profile (to ensure the CNI's implementation is compliant with API specifications).
+
+### Roadmap
+
+Planning is currently via GitHub issues.
+
+- Original issue for Policy Assistant: [#150](https://github.com/kubernetes-sigs/network-policy-api/issues/150).
+- First CLI release: [#255](https://github.com/kubernetes-sigs/network-policy-api/issues/255)
+
+### KubeCon EU 2024
+
+For a presentation and discussion on Policy Assistant and the admin policy APIs, see [this talk](https://youtu.be/riSv0g-TNtI?si=jiRy2mAKB0OVMFJF&t=1232).
+
+## Example Usage
+
+### Analyze
+
+> [!NOTE]
+> The CLI binary is still called "cyclonus". This will soon be renamed per [#254](https://github.com/kubernetes-sigs/network-policy-api/issues/254).
+
+#### "explain" mode
+
+Visualize all your policies in a table.
+
+```shell
+$ pola analyze --mode explain --policy-path cmd/policy-assistant/examples/demos/kubecon-eu-2024/policies/
+explained policies:
++---------+---------------------------------------+---------------------------+------------+----------------------------+--------------------------+
+|  TYPE   |                SUBJECT                |       SOURCE RULES        |    PEER    |           ACTION           |      PORT/PROTOCOL       |
++---------+---------------------------------------+---------------------------+------------+----------------------------+--------------------------+
+| Ingress | Namespace:                            | [NPv1] demo/deny-to-pod-a | no peers   | NPv1:                      | none                     |
+|         |    demo                               |                           |            |    Allow any peers         |                          |
+|         | Pod:                                  |                           |            |                            |                          |
+|         |    pod = a                            |                           |            |                            |                          |
++         +---------------------------------------+---------------------------+------------+----------------------------+--------------------------+
+|         | Namespace:                            | [ANP] default/anp1        | Namespace: | BANP:                      | all ports, all protocols |
+|         |    kubernetes.io/metadata.name = demo | [ANP] default/anp2        |    all     |    Deny                    |                          |
+|         |                                       | [ANP] default/anp3        | Pod:       |                            |                          |
+|         |                                       | [BANP] default/default    |    all     |                            |                          |
++         +                                       +                           +            +----------------------------+--------------------------+
+|         |                                       |                           |            | ANP:                       | port 80 on protocol TCP  |
+|         |                                       |                           |            |    pri=1 (allow-80): Allow |                          |
+|         |                                       |                           |            |                            |                          |
+|         |                                       |                           |            |                            |                          |
++         +                                       +                           +            +----------------------------+--------------------------+
+|         |                                       |                           |            | ANP:                       | port 81 on protocol TCP  |
+|         |                                       |                           |            |    pri=2 (pass-81): Pass   |                          |
+|         |                                       |                           |            |    pri=3 (deny-81): Deny   |                          |
+|         |                                       |                           |            |                            |                          |
++---------+---------------------------------------+---------------------------+------------+----------------------------+--------------------------+
+```
+
+#### "probe" mode
+
+> [!NOTE]
+> "walkthrough" mode is more intuitive and informative than "probe" mode.
+
+Visualize how traffic would be allowed/denied.
+
+```shell
+$ pola analyze --mode probe --probe-path examples/demos/kubecon-eu-2024/demo-probe.json --policy-path cmd/policy-assistant/examples/demos/kubecon-eu-2024/policies/
+probe (simulated connectivity):
+INFO[2024-08-07T17:26:28-07:00] probe on port 80, protocol TCP               
+Ingress:
++--------+--------+--------+
+|        | DEMO/A | DEMO/B |
++--------+--------+--------+
+| demo/a | #      | .      |
+| demo/b | X      | #      |
++--------+--------+--------+
+
+Egress:
++--------+--------+--------+
+|        | DEMO/A | DEMO/B |
++--------+--------+--------+
+| demo/a | #      | .      |
+| demo/b | .      | #      |
++--------+--------+--------+
+
+Combined:
++--------+--------+--------+
+|        | DEMO/A | DEMO/B |
++--------+--------+--------+
+| demo/a | #      | .      |
+| demo/b | X      | #      |
++--------+--------+--------+
+
+
+
+INFO[2024-08-07T17:26:28-07:00] probe on port 81, protocol TCP               
+Ingress:
++--------+--------+--------+
+|        | DEMO/A | DEMO/B |
++--------+--------+--------+
+| demo/a | #      | .      |
+| demo/b | X      | #      |
++--------+--------+--------+
+
+Egress:
++--------+--------+--------+
+|        | DEMO/A | DEMO/B |
++--------+--------+--------+
+| demo/a | #      | .      |
+| demo/b | .      | #      |
++--------+--------+--------+
+
+Combined:
++--------+--------+--------+
+|        | DEMO/A | DEMO/B |
++--------+--------+--------+
+| demo/a | #      | .      |
+| demo/b | X      | #      |
++--------+--------+--------+
+```
+
+#### "walkthrough" mode
+
+Visualize how traffic would be allowed/denied and which policies are causing the verdict.
+
+```shell
+$ pola analyze --mode walkthrough --policy-path cmd/policy-assistant/examples/demos/kubecon-eu-2024/policies/
+verdict walkthrough:
++---------------------------------------+---------+-------------------------------------------------------------+------------------------------+
+|                TRAFFIC                | VERDICT |                     INGRESS WALKTHROUGH                     |      EGRESS WALKTHROUGH      |
++---------------------------------------+---------+-------------------------------------------------------------+------------------------------+
+| demo/[pod=a] -> demo/[pod=b]:80 (TCP) | Allowed | [ANP] Allow (allow-80)                                      | no policies targeting egress |
++---------------------------------------+---------+-------------------------------------------------------------+                              +
+| demo/[pod=a] -> demo/[pod=b]:81 (TCP) | Denied  | [ANP] Pass (pass-81) -> [BANP] Deny (baseline-deny)         |                              |
++---------------------------------------+---------+-------------------------------------------------------------+                              +
+| demo/[pod=b] -> demo/[pod=a]:80 (TCP) | Allowed | [ANP] Allow (allow-80)                                      |                              |
++---------------------------------------+---------+-------------------------------------------------------------+                              +
+| demo/[pod=b] -> demo/[pod=a]:81 (TCP) | Denied  | [ANP] Pass (pass-81) -> [NPv1] Dropped (demo/deny-to-pod-a) |                              |
++---------------------------------------+---------+-------------------------------------------------------------+------------------------------+
+```
 
 ## Development
 
-Integration tests located at *test/integration/integration_test.go*. The tests verify:
+### Make from Source
+
+> [!NOTE]
+> The CLI binary is still called "cyclonus". This will soon be renamed per [#254](https://github.com/kubernetes-sigs/network-policy-api/issues/254).
+
+1. Clone the repo.
+2. `cd cmd/policy-assistant`
+3. `make cyclonus`
+4. The `cyclonus` binary will be produced at *cmd/cyclonus/cyclonus*.
+
+### Testing
+
+Run `go test ./...` in the *cmd/policy-assistant/* directory.
+
+Integration tests located at *test/integration/integration_test.go*.
+The tests verify:
 
 1. Building/translating Policy specs into interim data structures (matchers).
 2. Simulation of expected connectivity for ANP, BANP, and v1 NetPols.
+
+#### GitHub Action
+
+PRs must pass the GitHub Action for Policy Assistant specified under *.github/*.

--- a/cmd/policy-assistant/examples/demos/kubecon-eu-2024/demo-probe.json
+++ b/cmd/policy-assistant/examples/demos/kubecon-eu-2024/demo-probe.json
@@ -1,0 +1,33 @@
+{
+  "Probes": [
+    {
+      "Protocol": "TCP",
+      "Port": 80
+    },
+    {
+      "Protocol": "TCP",
+      "Port": 81
+    }
+  ],
+  "Resources": {
+    "Namespaces": {
+      "demo": {"ns": "demo"}
+    },
+    "Pods": [
+      {
+        "Namespace": "demo",
+        "Name": "a",
+        "Labels": {"pod": "a"},
+        "IP": "192.168.1.8",
+        "Containers": [{"Name": "cont-1", "Port": 80, "PortName": "serve-80-tcp","Protocol": "tcp"}, {"Name": "cont-2", "Port": 81, "PortName": "serve-81-tcp","Protocol": "tcp"}]
+      },
+      {
+        "Namespace": "demo",
+        "Name": "b",
+        "Labels": {"pod": "b"},
+        "IP": "192.168.1.9",
+        "Containers": [{"Name": "cont-1", "Port": 80, "PortName": "serve-80-tcp","Protocol": "tcp"}, {"Name": "cont-2", "Port": 81, "PortName": "serve-81-tcp","Protocol": "tcp"}]
+      }
+    ]
+  }
+}

--- a/cmd/policy-assistant/examples/demos/kubecon-eu-2024/policies/anp1.yaml
+++ b/cmd/policy-assistant/examples/demos/kubecon-eu-2024/policies/anp1.yaml
@@ -1,0 +1,20 @@
+apiVersion: policy.networking.k8s.io/v1alpha1
+kind: AdminNetworkPolicy
+metadata:
+  name: anp1
+spec:
+  priority: 1
+  subject:
+    namespaces:
+      matchLabels:
+        kubernetes.io/metadata.name: demo
+  ingress:
+  - name: "allow-80"
+    action: "Allow"
+    from:
+    - namespaces:
+        namespaceSelector: {}
+    ports:
+      - portNumber:
+          protocol: TCP
+          port: 80

--- a/cmd/policy-assistant/examples/demos/kubecon-eu-2024/policies/anp2.yaml
+++ b/cmd/policy-assistant/examples/demos/kubecon-eu-2024/policies/anp2.yaml
@@ -1,0 +1,20 @@
+apiVersion: policy.networking.k8s.io/v1alpha1
+kind: AdminNetworkPolicy
+metadata:
+  name: anp2
+spec:
+  priority: 2
+  subject:
+    namespaces:
+      matchLabels:
+        kubernetes.io/metadata.name: demo
+  ingress:
+  - name: "pass-81"
+    action: "Pass"
+    from:
+    - namespaces:
+        namespaceSelector: {}
+    ports:
+      - portNumber:
+          protocol: TCP
+          port: 81

--- a/cmd/policy-assistant/examples/demos/kubecon-eu-2024/policies/anp3.yaml
+++ b/cmd/policy-assistant/examples/demos/kubecon-eu-2024/policies/anp3.yaml
@@ -1,0 +1,20 @@
+apiVersion: policy.networking.k8s.io/v1alpha1
+kind: AdminNetworkPolicy
+metadata:
+  name: anp3
+spec:
+  priority: 3
+  subject:
+    namespaces:
+      matchLabels:
+        kubernetes.io/metadata.name: demo
+  ingress:
+  - name: "deny-81"
+    action: "Deny"
+    from:
+    - namespaces:
+        namespaceSelector: {}
+    ports:
+      - portNumber:
+          protocol: TCP
+          port: 81

--- a/cmd/policy-assistant/examples/demos/kubecon-eu-2024/policies/banp.yaml
+++ b/cmd/policy-assistant/examples/demos/kubecon-eu-2024/policies/banp.yaml
@@ -1,0 +1,15 @@
+apiVersion: policy.networking.k8s.io/v1alpha1
+kind: BaselineAdminNetworkPolicy
+metadata:
+  name: default
+spec:
+  subject:
+    namespaces:
+      matchLabels:
+        kubernetes.io/metadata.name: demo
+  ingress:
+  - name: "baseline-deny"
+    action: "Deny"
+    from:
+    - namespaces:
+        namespaceSelector: {}

--- a/cmd/policy-assistant/examples/demos/kubecon-eu-2024/policies/npv1.yaml
+++ b/cmd/policy-assistant/examples/demos/kubecon-eu-2024/policies/npv1.yaml
@@ -1,0 +1,12 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: deny-to-pod-a
+  namespace: demo
+spec:
+  policyTypes:
+    - Ingress
+  podSelector:
+    matchLabels:
+      pod: a
+  ingress: []

--- a/cmd/policy-assistant/go.mod
+++ b/cmd/policy-assistant/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.8.2
 	golang.org/x/exp v0.0.0-20220706164943-b4a6d9510983
+	golang.org/x/net v0.14.0
 	k8s.io/api v0.28.1
 	k8s.io/apimachinery v0.28.1
 	k8s.io/client-go v0.28.1
@@ -48,7 +49,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	golang.org/x/net v0.14.0 // indirect
 	golang.org/x/oauth2 v0.8.0 // indirect
 	golang.org/x/sys v0.11.0 // indirect
 	golang.org/x/term v0.11.0 // indirect

--- a/cmd/policy-assistant/pkg/cli/analyze.go
+++ b/cmd/policy-assistant/pkg/cli/analyze.go
@@ -84,7 +84,7 @@ func SetupAnalyzeCommand() *cobra.Command {
 	command.Flags().StringSliceVarP(&args.Namespaces, "namespace", "n", []string{}, "namespaces to read kube resources from; similar to kubectl's '--namespace'/'-n' flag, except that multiple namespaces may be passed in and is empty if not set explicitly (instead of 'default' as in kubectl)")
 	command.Flags().StringVar(&args.PolicyPath, "policy-path", "", "may be a file or a directory; if set, will attempt to read policies from the path")
 	command.Flags().StringVar(&args.Context, "context", "", "selects kube context to read policies from; only reads from kube if one or more namespaces or all namespaces are specified")
-	command.Flags().BoolVar(&args.SimplifyPolicies, "simplify-policies", true, "if true, reduce policies to simpler form while preserving semantics")
+	command.Flags().BoolVar(&args.SimplifyPolicies, "simplify-policies", true, "if true, reduce policies to simpler form while preserving semantics (only applies to NPv1 currently)")
 
 	command.Flags().StringSliceVar(&args.Modes, "mode", []string{ExplainMode}, "analysis modes to run; allowed values are "+strings.Join(AllModes, ","))
 

--- a/cmd/policy-assistant/pkg/cli/analyze_unimplemented.go
+++ b/cmd/policy-assistant/pkg/cli/analyze_unimplemented.go
@@ -1,0 +1,99 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/mattfenwick/collections/pkg/json"
+	"github.com/mattfenwick/cyclonus/pkg/kube"
+	"github.com/mattfenwick/cyclonus/pkg/matcher"
+	"github.com/mattfenwick/cyclonus/pkg/utils"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// case ParseMode:
+//
+//	fmt.Println("parsed policies:")
+//	ParsePolicies(kubePolicies)
+func ParsePolicies(kubePolicies []*networkingv1.NetworkPolicy) {
+	fmt.Println(kube.NetworkPoliciesToTable(kubePolicies))
+}
+
+// case QueryTargetMode:
+// 	pods := make([]*QueryTargetPod, len(kubePods))
+// 	for i, p := range kubePods {
+// 		pods[i] = &QueryTargetPod{
+// 			Namespace: p.Namespace,
+// 			Labels:    p.Labels,
+// 		}
+// 	}
+// 	fmt.Println("query target:")
+// 	QueryTargets(policies, args.TargetPodPath, pods)
+// case QueryTrafficMode:
+// 	fmt.Println("query traffic:")
+// 	QueryTraffic(policies, args.TrafficPath)
+
+// QueryTargetPod matches targets; targets exist in only a single namespace and can't be matched by namespace
+//
+//	label, therefore we match by exact namespace and by pod labels.
+type QueryTargetPod struct {
+	Namespace string
+	Labels    map[string]string
+}
+
+func QueryTargets(explainedPolicies *matcher.Policy, podPath string, pods []*QueryTargetPod) {
+	if podPath != "" {
+		podsFromFile, err := json.ParseFile[[]*QueryTargetPod](podPath)
+		utils.DoOrDie(err)
+		pods = append(pods, *podsFromFile...)
+	}
+
+	for _, pod := range pods {
+		fmt.Printf("pod in ns %s with labels %+v:\n\n", pod.Namespace, pod.Labels)
+
+		targets, combinedRules := QueryTargetHelper(explainedPolicies, pod)
+
+		fmt.Printf("Matching targets:\n%s\n", targets.ExplainTable())
+		fmt.Printf("Combined rules:\n%s\n\n\n", combinedRules.ExplainTable())
+	}
+}
+
+func QueryTargetHelper(policies *matcher.Policy, pod *QueryTargetPod) (*matcher.Policy, *matcher.Policy) {
+	podInfo := &matcher.InternalPeer{
+		Namespace: pod.Namespace,
+		PodLabels: pod.Labels,
+	}
+	ingressTargets := policies.TargetsApplyingToPod(true, podInfo)
+	combinedIngressTarget := matcher.CombineTargetsIgnoringPrimaryKey(pod.Namespace, metav1.LabelSelector{MatchLabels: pod.Labels}, ingressTargets)
+
+	egressTargets := policies.TargetsApplyingToPod(false, podInfo)
+	combinedEgressTarget := matcher.CombineTargetsIgnoringPrimaryKey(pod.Namespace, metav1.LabelSelector{MatchLabels: pod.Labels}, egressTargets)
+
+	var combinedIngresses []*matcher.Target
+	if combinedIngressTarget != nil {
+		combinedIngresses = []*matcher.Target{combinedIngressTarget}
+	}
+	var combinedEgresses []*matcher.Target
+	if combinedEgressTarget != nil {
+		combinedEgresses = []*matcher.Target{combinedEgressTarget}
+	}
+
+	return matcher.NewPolicyWithTargets(ingressTargets, egressTargets), matcher.NewPolicyWithTargets(combinedIngresses, combinedEgresses)
+}
+
+func QueryTraffic(explainedPolicies *matcher.Policy, trafficPath string) {
+	if trafficPath == "" {
+		logrus.Fatalf("%+v", errors.Errorf("path to traffic file required for QueryTraffic command"))
+	}
+	allTraffics, err := json.ParseFile[[]*matcher.Traffic](trafficPath)
+	utils.DoOrDie(err)
+
+	for _, traffic := range *allTraffics {
+		fmt.Printf("Traffic:\n%s\n", traffic.Table())
+
+		result := explainedPolicies.IsTrafficAllowed(traffic)
+		fmt.Printf("Is traffic allowed?\n%s\n\n\n", result.Table())
+	}
+}

--- a/cmd/policy-assistant/pkg/kube/kubernetes.go
+++ b/cmd/policy-assistant/pkg/kube/kubernetes.go
@@ -3,6 +3,7 @@ package kube
 import (
 	"bytes"
 	"context"
+
 	v1alpha12 "sigs.k8s.io/network-policy-api/apis/v1alpha1"
 	"sigs.k8s.io/network-policy-api/pkg/client/clientset/versioned/typed/apis/v1alpha1"
 

--- a/cmd/policy-assistant/pkg/matcher/explain.go
+++ b/cmd/policy-assistant/pkg/matcher/explain.go
@@ -101,7 +101,7 @@ func (s *SliceBuilder) TargetsTableLines(targets []*Target, isIngress bool) {
 			case *IPPeerMatcher:
 				s.IPPeerMatcherTableLines(t)
 			case *PodPeerMatcher:
-				s.Append(resolveSubject(t), "NPv1:\n   Allow any peers", strings.Join(PortMatcherTableLines(t.Port, NewV1Effect(true).PolicyKind), "\n"))
+				s.Append(resolveSubject(t), "NPv1:\n   Allow any peers", strings.Join(PortMatcherTableLines(t.Port, NetworkPolicyV1), "\n"))
 			case *peerProtocolGroup:
 				s.peerProtocolGroupTableLines(t)
 			default:

--- a/cmd/policy-assistant/pkg/matcher/peermatcherv2.go
+++ b/cmd/policy-assistant/pkg/matcher/peermatcherv2.go
@@ -1,6 +1,9 @@
 package matcher
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/pkg/errors"
 	"sigs.k8s.io/network-policy-api/apis/v1alpha1"
 )
@@ -61,11 +64,18 @@ const (
 	BaselineAdminNetworkPolicy PolicyKind = "BANP"
 )
 
-func NewV1Effect(allow bool) Effect {
-	if allow {
-		return Effect{"", NetworkPolicyV1, 0, Allow}
+func NewV1Effect(allow bool, policyNames []string) Effect {
+	// remove [NPv1] prefix if present
+	cleanNames := make([]string, len(policyNames))
+	for i, name := range policyNames {
+		cleanNames[i] = strings.Replace(name, fmt.Sprintf("[%s] ", NetworkPolicyV1), "", -1)
 	}
-	return Effect{"", NetworkPolicyV1, 0, None}
+	joinedNames := strings.Join(cleanNames, ", ")
+
+	if allow {
+		return Effect{joinedNames, NetworkPolicyV1, 0, Allow}
+	}
+	return Effect{joinedNames, NetworkPolicyV1, 0, None}
 }
 
 type Verdict string

--- a/cmd/policy-assistant/pkg/matcher/policy.go
+++ b/cmd/policy-assistant/pkg/matcher/policy.go
@@ -262,6 +262,13 @@ func (ar *AllowedResult) IsAllowed() bool {
 	return ar.Ingress.IsAllowed() && ar.Egress.IsAllowed()
 }
 
+func (ar *AllowedResult) Verdict() string {
+	if ar.IsAllowed() {
+		return "Allowed"
+	}
+	return "Denied"
+}
+
 // IsTrafficAllowed returns:
 // - whether the traffic is allowed
 // - which rules allowed the traffic

--- a/cmd/policy-assistant/pkg/matcher/traffic.go
+++ b/cmd/policy-assistant/pkg/matcher/traffic.go
@@ -58,6 +58,38 @@ func labelsToString(labels map[string]string) string {
 	return strings.Join(slice.Map(format, slice.Sort(maps.Keys(labels))), "\n")
 }
 
+func (t *Traffic) PrettyString() string {
+	if t == nil || t.Source == nil || t.Destination == nil {
+		return "<undefined>"
+	}
+
+	src := t.Source.Internal.Workload
+	if src == "" {
+		if t.Source.Internal == nil {
+			return "<undefined>"
+		}
+
+		src = fmt.Sprintf("%s/%s", t.Source.Internal.Namespace, labelsToStringSlim(t.Source.Internal.PodLabels))
+	}
+
+	dst := t.Destination.Internal.Workload
+	if dst == "" {
+		if t.Destination.Internal == nil {
+			return "<undefined>"
+		}
+
+		dst = fmt.Sprintf("%s/%s", t.Destination.Internal.Namespace, labelsToStringSlim(t.Destination.Internal.PodLabels))
+	}
+
+	return fmt.Sprintf("%s -> %s:%d (%s)", src, dst, t.ResolvedPort, t.Protocol)
+}
+
+func labelsToStringSlim(labels map[string]string) string {
+	format := func(k string) string { return fmt.Sprintf("%s=%s", k, labels[k]) }
+	list := strings.Join(slice.Map(format, slice.Sort(maps.Keys(labels))), ",")
+	return fmt.Sprintf("[%s]", list)
+}
+
 type TrafficPeer struct {
 	Internal *InternalPeer
 	// IP external to cluster

--- a/cmd/policy-assistant/test/integration/probe_test.go
+++ b/cmd/policy-assistant/test/integration/probe_test.go
@@ -1,0 +1,26 @@
+package connectivity
+
+import (
+	"testing"
+
+	"github.com/mattfenwick/cyclonus/pkg/cli"
+	"github.com/mattfenwick/cyclonus/pkg/kube"
+	"github.com/mattfenwick/cyclonus/pkg/matcher"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProbe(t *testing.T) {
+	t.Run("probe works", func(t *testing.T) {
+		npv1, anp, banp, err := kube.ReadNetworkPoliciesFromPath("../../examples/demos/kubecon-eu-2024/policies/")
+		require.Nil(t, err)
+
+		policies := matcher.BuildV1AndV2NetPols(false, npv1, anp, banp)
+
+		cli.ProbeSyntheticConnectivity(policies, "../../examples/demos/kubecon-eu-2024/demo-probe.json", nil, nil)
+
+		cli.RunAnalyzeCommand(&cli.AnalyzeArgs{
+			PolicyPath: "../../examples/demos/kubecon-eu-2024/policies/",
+			ProbePath:  "../../examples/demos/kubecon-eu-2024/demo-probe.json",
+		})
+	})
+}


### PR DESCRIPTION
- Finally adding a good README for the project.
- Walkthrough mode is as seen at KubeCon, but the code is no longer as hacky. Fixes #168. 
- Probe mode is working too. Fixes #210
- Remove unimplemented analyze modes (related to #151). Supported modes are now:
  - `--mode strings     analysis modes to run; allowed values are explain,probe,walkthrough (default [explain])`
- Files used for the demo are included in _examples/demos/_.

### Outputs
#### walkthrough

Fixes #168. NOTE: the traffic is hardcoded right now. Need to fix in a followup PR that leverages #227 to specify traffic for the walkthrough.

```shell
./cmd/cyclonus/cyclonus analyze --policy-path examples/demos/kubecon-eu-2024/policies --mode walkthrough
INFO[2024-10-25T15:14:01-07:00] log level set to 'info'                      
verdict walkthrough:
+---------------------------------------+---------+-------------------------------------------------------------+------------------------------+
|                TRAFFIC                | VERDICT |                     INGRESS WALKTHROUGH                     |      EGRESS WALKTHROUGH      |
+---------------------------------------+---------+-------------------------------------------------------------+------------------------------+
| demo/[pod=a] -> demo/[pod=b]:80 (TCP) | Allowed | [ANP] Allow (allow-80)                                      | no policies targeting egress |
+---------------------------------------+---------+-------------------------------------------------------------+                              +
| demo/[pod=a] -> demo/[pod=b]:81 (TCP) | Denied  | [ANP] Pass (pass-81) -> [BANP] Deny (baseline-deny)         |                              |
+---------------------------------------+---------+-------------------------------------------------------------+                              +
| demo/[pod=b] -> demo/[pod=a]:80 (TCP) | Allowed | [ANP] Allow (allow-80)                                      |                              |
+---------------------------------------+---------+-------------------------------------------------------------+                              +
| demo/[pod=b] -> demo/[pod=a]:81 (TCP) | Denied  | [ANP] Pass (pass-81) -> [NPv1] Dropped (demo/deny-to-pod-a) |                              |
+---------------------------------------+---------+-------------------------------------------------------------+------------------------------+
```

#### probe

Fixes #210 

```shell
./cmd/cyclonus/cyclonus analyze --mode probe --policy-path examples/demos/kubecon-eu-2024/policies --probe-path examples/dem
os/kubecon-eu-2024/demo-probe.json
INFO[2024-10-25T15:12:22-07:00] log level set to 'info'                      
probe (simulated connectivity):
INFO[2024-10-25T15:12:22-07:00] probe on port 80, protocol TCP               
Ingress:
+--------+--------+--------+
|        | DEMO/A | DEMO/B |
+--------+--------+--------+
| demo/a | #      | .      |
| demo/b | X      | #      |
+--------+--------+--------+

Egress:
+--------+--------+--------+
|        | DEMO/A | DEMO/B |
+--------+--------+--------+
| demo/a | #      | .      |
| demo/b | .      | #      |
+--------+--------+--------+

Combined:
+--------+--------+--------+
|        | DEMO/A | DEMO/B |
+--------+--------+--------+
| demo/a | #      | .      |
| demo/b | X      | #      |
+--------+--------+--------+



INFO[2024-10-25T15:12:22-07:00] probe on port 81, protocol TCP               
Ingress:
+--------+--------+--------+
|        | DEMO/A | DEMO/B |
+--------+--------+--------+
| demo/a | #      | .      |
| demo/b | X      | #      |
+--------+--------+--------+

Egress:
+--------+--------+--------+
|        | DEMO/A | DEMO/B |
+--------+--------+--------+
| demo/a | #      | .      |
| demo/b | .      | #      |
+--------+--------+--------+

Combined:
+--------+--------+--------+
|        | DEMO/A | DEMO/B |
+--------+--------+--------+
| demo/a | #      | .      |
| demo/b | X      | #      |
+--------+--------+--------+
```