### PR TITLE
Disallow empty port list for ANP peers.

### DIFF
--- a/apis/v1alpha1/adminnetworkpolicy_types.go
+++ b/apis/v1alpha1/adminnetworkpolicy_types.go
@@ -155,6 +155,7 @@ type AdminNetworkPolicyIngressRule struct {
 	// Support: Core
 	//
 	// +optional
+	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=100
 	Ports *[]AdminNetworkPolicyPort `json:"ports,omitempty"`
 }
@@ -207,6 +208,7 @@ type AdminNetworkPolicyEgressRule struct {
 	// Support: Core
 	//
 	// +optional
+	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=100
 	Ports *[]AdminNetworkPolicyPort `json:"ports,omitempty"`
 }

--- a/apis/v1alpha1/baselineadminnetworkpolicy_types.go
+++ b/apis/v1alpha1/baselineadminnetworkpolicy_types.go
@@ -136,6 +136,7 @@ type BaselineAdminNetworkPolicyIngressRule struct {
 	// Support: Core
 	//
 	// +optional
+	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=100
 	Ports *[]AdminNetworkPolicyPort `json:"ports,omitempty"`
 }
@@ -181,6 +182,7 @@ type BaselineAdminNetworkPolicyEgressRule struct {
 	// This field is a list of destination ports for the outgoing egress traffic.
 	// If Ports is not set then the rule does not filter traffic via port.
 	// +optional
+	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=100
 	Ports *[]AdminNetworkPolicyPort `json:"ports,omitempty"`
 }

--- a/config/crd/experimental/policy.networking.k8s.io_adminnetworkpolicies.yaml
+++ b/config/crd/experimental/policy.networking.k8s.io_adminnetworkpolicies.yaml
@@ -200,6 +200,7 @@ spec:
                             type: object
                         type: object
                       maxItems: 100
+                      minItems: 1
                       type: array
                     to:
                       description: |-
@@ -869,6 +870,7 @@ spec:
                             type: object
                         type: object
                       maxItems: 100
+                      minItems: 1
                       type: array
                   required:
                   - action

--- a/config/crd/experimental/policy.networking.k8s.io_baselineadminnetworkpolicies.yaml
+++ b/config/crd/experimental/policy.networking.k8s.io_baselineadminnetworkpolicies.yaml
@@ -190,6 +190,7 @@ spec:
                             type: object
                         type: object
                       maxItems: 100
+                      minItems: 1
                       type: array
                     to:
                       description: |-
@@ -808,6 +809,7 @@ spec:
                             type: object
                         type: object
                       maxItems: 100
+                      minItems: 1
                       type: array
                   required:
                   - action

--- a/config/crd/standard/policy.networking.k8s.io_adminnetworkpolicies.yaml
+++ b/config/crd/standard/policy.networking.k8s.io_adminnetworkpolicies.yaml
@@ -190,6 +190,7 @@ spec:
                             type: object
                         type: object
                       maxItems: 100
+                      minItems: 1
                       type: array
                     to:
                       description: |-
@@ -704,6 +705,7 @@ spec:
                             type: object
                         type: object
                       maxItems: 100
+                      minItems: 1
                       type: array
                   required:
                   - action

--- a/config/crd/standard/policy.networking.k8s.io_baselineadminnetworkpolicies.yaml
+++ b/config/crd/standard/policy.networking.k8s.io_baselineadminnetworkpolicies.yaml
@@ -180,6 +180,7 @@ spec:
                             type: object
                         type: object
                       maxItems: 100
+                      minItems: 1
                       type: array
                     to:
                       description: |-
@@ -690,6 +691,7 @@ spec:
                             type: object
                         type: object
                       maxItems: 100
+                      minItems: 1
                       type: array
                   required:
                   - action


### PR DESCRIPTION
Based on discussion https://github.com/kubernetes-sigs/network-policy-api/issues/247
Zero-length port list is different from the nil port list, and it means do not match any port, which makes that peer not matching any traffic. 
This is confusing and is more of an accident than an intention.