### PR TITLE
Update github action upload-artifacts version.

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -97,7 +97,7 @@ jobs:
 
     - name: Upload Junit Reports
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: kind-junit-${{ env.JOB_NAME }}-${{ github.run_id }}
         path: './_artifacts/*.xml'
@@ -109,7 +109,7 @@ jobs:
 
     - name: Upload logs
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: kind-logs-${{ env.JOB_NAME }}-${{ github.run_id }}
         path: ./_artifacts/logs

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,13 +14,9 @@ linters:
   - revive
   - govet
   - misspell
-  - exportloopref
+  - copyloopvar
   - unused
   disable:
-  - scopelint
-  - deadcode
-  - structcheck
-  - varcheck
   - rowserrcheck
   - sqlclosecheck
   disable-all: false
@@ -39,7 +35,7 @@ linters-settings:
     min-confidence: 0.9
   govet:
     # report about shadowed variables
-    check-shadowing: true
+    shadow: true
   misspell:
     locale: US
     ignore-words:

--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly VERSION="v1.55.2"
+readonly VERSION="v1.61.0"
 KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 readonly KUBE_ROOT
 
@@ -29,4 +29,4 @@ echo "Installing golangci-lint..."
 curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s "$VERSION"
 
 echo "Running golangci-lint..."
-./bin/golangci-lint run --deadline=10m
+./bin/golangci-lint run --timeout=10m


### PR DESCRIPTION
Based on the deprecation notice https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
Failing job example https://github.com/kubernetes-sigs/network-policy-api/actions/runs/11253153563/job/31287810457?pr=250

Update golangci-lint to v1.61.0, fix linters list for the latest version