### PR TITLE
fix: [Policy Assistant] translate could grab labels from other pods

### DIFF
--- a/.github/workflows/policy-assistant.yml
+++ b/.github/workflows/policy-assistant.yml
@@ -116,4 +116,4 @@ jobs:
 
     - name: Run Integration Test - Walkthrough Mode
       run: |
-        artifacts/policy-assistant analyze --mode walkthrough --policy-path cmd/policy-assistant/examples/demos/kubecon-eu-2024/policies/
+        artifacts/policy-assistant analyze --mode walkthrough --policy-path cmd/policy-assistant/examples/demos/kubecon-eu-2024/policies/ --traffic-path cmd/policy-assistant/examples/traffic-example.json


### PR DESCRIPTION
Fixes a bug in `policy-assistant analyze --mode walkthrough` resulting in incorrect policy verdicts because `Translate()` could return Pod B's metadata when translating Pod A.

This was a bug of variable scope for `workloadOwner` and `workloadKind`. This PR moves variables closer to their usage at the proper scope.