### PR TITLE
chore(goreleaser): [Policy Assistant] fix format of checksum file

### DIFF
--- a/cmd/policy-assistant/.goreleaser.yml
+++ b/cmd/policy-assistant/.goreleaser.yml
@@ -57,5 +57,5 @@ archives:
       - README*
       - CHANGELOG*
 checksum:
-  name_template: "policy_assistant_{{ .RawVersion }}_checksums.txt"
+  name_template: "policy-assistant_v{{ .Version }}_checksums.txt"
   algorithm: sha256


### PR DESCRIPTION
For the tag `v0.0.1-policy-assistant`, the checksum file looks like:
`policy_assistant_0.0.1_checksums.txt`

This PR:
1. Changes `policy_assistant` to `policy-assistant`
2. Stops truncating the version at the first hyphen (`0.0.1` to `v0.0.1-policy-assistant`)

New checksum file: 
`policy-assistant_v0.0.1-policy-assistant-SNAPSHOT-8a8d312_checksums.txt`

### goreleaser output

noting the full output:

![{34AF286B-EB6B-4EC3-A50F-DD81AB4DC8EF}](https://github.com/user-attachments/assets/27aca6e8-8247-42f3-ae33-cfc236714f4a)

```
$ goreleaser release --snapshot --clean
  • only configurations files on  version: 2  are supported, yours is  version: 0 , please update your configuration
  • skipping announce, publish and validate...
  • cleaning distribution directory
  • loading environment variables
  • getting and validating git state
    • git state                                      commit=8a8d31217326e5cb23c955995d2adddcb73daea0 branch=goreleaser current_tag=v0.0.1-policy-assistant previous_tag=v0.1.5 dirty=false
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • snapshotting
    • building snapshot...                           version=0.0.1-policy-assistant-SNAPSHOT-8a8d312
  • ensuring distribution directory
  • setting up metadata
  • writing release metadata
  • loading go mod information
  • build prerequisites
  • building binaries
    • building                                       binary=dist/policy-assistant_windows_amd64_v1/policy-assistant.exe
    • building                                       binary=dist/policy-assistant_darwin_amd64_v1/policy-assistant
    • building                                       binary=dist/policy-assistant_linux_amd64_v1/policy-assistant
  • archives
    • creating                                       archive=dist/policy-assistant_windows_amd64.zip
    • creating                                       archive=dist/policy-assistant_darwin_amd64.tar.gz
    • creating                                       archive=dist/policy-assistant_linux_amd64.tar.gz
  • calculating checksums
  • writing artifacts metadata
  • release succeeded after 5s
  • thanks for using goreleaser!
```