### PR TITLE
update to golangci-lint 1.64.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea/
 .vscode/
+bin/
 vendor/
 site/
 .DS_Store

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,6 @@ run:
   timeout: 10m
   issues-exit-code: 1
   tests: true
-  skip-dirs-use-default: true
   modules-download-mode: readonly
   allow-parallel-runners: false
 
@@ -41,6 +40,7 @@ linters-settings:
     ignore-words:
 
 issues:
+  exclude-dirs-use-default: true
   exclude-rules:
     # Exclude some linters from running on tests files.
     - path: _test\.go

--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly VERSION="v1.61.0"
+readonly VERSION="v1.64.7"
 KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 readonly KUBE_ROOT
 


### PR DESCRIPTION
golangci-lint seems to be failing on `main` for some reason (eg, [here](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_network-policy-api/252/pull-network-policy-api-verify/1904204142750994432), from #252).

Updating to the latest release fixes the problem. :man_shrugging: 

Also, we were previously accidentally committing the golangci-lint binary to github, so fix that.