### PR TITLE
Graduate `networks` to standard

### DIFF
--- a/apis/v1alpha1/adminnetworkpolicy_types.go
+++ b/apis/v1alpha1/adminnetworkpolicy_types.go
@@ -245,7 +245,6 @@ type AdminNetworkPolicyEgressPeer struct {
 	//
 	// Networks can have upto 25 CIDRs specified.
 	//
-	// <network-policy-api:experimental>
 	// +optional
 	// +listType=set
 	// +kubebuilder:validation:MinItems=1

--- a/apis/v1alpha1/baselineadminnetworkpolicy_types.go
+++ b/apis/v1alpha1/baselineadminnetworkpolicy_types.go
@@ -222,7 +222,6 @@ type BaselineAdminNetworkPolicyEgressPeer struct {
 	//
 	// Networks can have upto 25 CIDRs specified.
 	//
-	// <network-policy-api:experimental>
 	// +optional
 	// +listType=set
 	// +kubebuilder:validation:MinItems=1

--- a/config/crd/experimental/policy.networking.k8s.io_adminnetworkpolicies.yaml
+++ b/config/crd/experimental/policy.networking.k8s.io_adminnetworkpolicies.yaml
@@ -285,8 +285,6 @@ spec:
                               IPv4 or IPv6, for example "10.0.0.0/8" or "fd00::/8".
 
                               Networks can have upto 25 CIDRs specified.
-
-                              <network-policy-api:experimental>
                             items:
                               description: CIDR is an IP address range in CIDR notation
                                 (for example, "10.0.0.0/8" or "fd00::/8").

--- a/config/crd/experimental/policy.networking.k8s.io_baselineadminnetworkpolicies.yaml
+++ b/config/crd/experimental/policy.networking.k8s.io_baselineadminnetworkpolicies.yaml
@@ -240,8 +240,6 @@ spec:
                               IPv4 or IPv6, for example "10.0.0.0/8" or "fd00::/8".
 
                               Networks can have upto 25 CIDRs specified.
-
-                              <network-policy-api:experimental>
                             items:
                               description: CIDR is an IP address range in CIDR notation
                                 (for example, "10.0.0.0/8" or "fd00::/8").

--- a/config/crd/standard/policy.networking.k8s.io_adminnetworkpolicies.yaml
+++ b/config/crd/standard/policy.networking.k8s.io_adminnetworkpolicies.yaml
@@ -227,6 +227,32 @@ spec:
                                 type: object
                             type: object
                             x-kubernetes-map-type: atomic
+                          networks:
+                            description: |-
+                              Networks defines a way to select peers via CIDR blocks.
+                              This is intended for representing entities that live outside the cluster,
+                              which can't be selected by pods, namespaces and nodes peers, but note
+                              that cluster-internal traffic will be checked against the rule as
+                              well. So if you Allow or Deny traffic to `"0.0.0.0/0"`, that will allow
+                              or deny all IPv4 pod-to-pod traffic as well. If you don't want that,
+                              add a rule that Passes all pod traffic before the Networks rule.
+
+                              Each item in Networks should be provided in the CIDR format and should be
+                              IPv4 or IPv6, for example "10.0.0.0/8" or "fd00::/8".
+
+                              Networks can have upto 25 CIDRs specified.
+                            items:
+                              description: CIDR is an IP address range in CIDR notation
+                                (for example, "10.0.0.0/8" or "fd00::/8").
+                              maxLength: 43
+                              type: string
+                              x-kubernetes-validations:
+                              - message: Invalid CIDR format provided
+                                rule: isCIDR(self)
+                            maxItems: 25
+                            minItems: 1
+                            type: array
+                            x-kubernetes-list-type: set
                           pods:
                             description: |-
                               Pods defines a way to select a set of pods in

--- a/config/crd/standard/policy.networking.k8s.io_baselineadminnetworkpolicies.yaml
+++ b/config/crd/standard/policy.networking.k8s.io_baselineadminnetworkpolicies.yaml
@@ -220,6 +220,32 @@ spec:
                                 type: object
                             type: object
                             x-kubernetes-map-type: atomic
+                          networks:
+                            description: |-
+                              Networks defines a way to select peers via CIDR blocks.
+                              This is intended for representing entities that live outside the cluster,
+                              which can't be selected by pods, namespaces and nodes peers, but note
+                              that cluster-internal traffic will be checked against the rule as
+                              well. So if you Allow or Deny traffic to `"0.0.0.0/0"`, that will allow
+                              or deny all IPv4 pod-to-pod traffic as well. If you don't want that,
+                              add a rule that Passes all pod traffic before the Networks rule.
+
+                              Each item in Networks should be provided in the CIDR format and should be
+                              IPv4 or IPv6, for example "10.0.0.0/8" or "fd00::/8".
+
+                              Networks can have upto 25 CIDRs specified.
+                            items:
+                              description: CIDR is an IP address range in CIDR notation
+                                (for example, "10.0.0.0/8" or "fd00::/8").
+                              maxLength: 43
+                              type: string
+                              x-kubernetes-validations:
+                              - message: Invalid CIDR format provided
+                                rule: isCIDR(self)
+                            maxItems: 25
+                            minItems: 1
+                            type: array
+                            x-kubernetes-list-type: set
                           pods:
                             description: |-
                               Pods defines a way to select a set of pods in

--- a/conformance/base/admin_network_policy/standard-egress-inline-cidr-rules.yaml
+++ b/conformance/base/admin_network_policy/standard-egress-inline-cidr-rules.yaml
@@ -1,0 +1,38 @@
+apiVersion: policy.networking.k8s.io/v1alpha1
+kind: AdminNetworkPolicy
+metadata:
+  name: inline-cidr-as-peers-example
+spec:
+  priority: 85
+  subject:
+    pods:
+      namespaceSelector:
+        matchLabels:
+          conformance-house: gryffindor
+      podSelector:
+        matchLabels:
+          conformance-house: gryffindor
+  egress:
+  # CIDR rules that test allow to specific IPs is done within the test by updating the CR
+  #- name: "allow-egress-to-specific-podIPs"
+  #  action: "Allow"
+  #  to:
+  #  - networks:
+  #    - luna-lovegood-0.IP
+  #    - cedric-diggory-0.IP
+  - name: "allow-egress-to-slytherin"
+    action: "Allow"
+    to:
+    - pods:
+        namespaceSelector:
+          matchLabels:
+            conformance-house: slytherin
+        podSelector:
+          matchLabels:
+            conformance-house: slytherin
+  - name: "deny-egress-to-internet"
+    action: "Deny"
+    to:
+    - networks:
+        - 0.0.0.0/0
+        - ::/0

--- a/conformance/base/admin_network_policy/standard-gress-rules-combined.yaml
+++ b/conformance/base/admin_network_policy/standard-gress-rules-combined.yaml
@@ -59,7 +59,7 @@ spec:
       - portNumber:
           protocol: SCTP
           port: 9003
-  - name: "allow-to-hufflepuff-at-ports-8080-5353"
+  - name: "allow-to-hufflepuff-at-ports-8080-5353-9003"
     action: "Allow"
     to:
     - namespaces:

--- a/conformance/base/baseline_admin_network_policy/standard-egress-inline-cidr-rules.yaml
+++ b/conformance/base/baseline_admin_network_policy/standard-egress-inline-cidr-rules.yaml
@@ -1,0 +1,33 @@
+apiVersion: policy.networking.k8s.io/v1alpha1
+kind: BaselineAdminNetworkPolicy
+metadata:
+  name: default
+spec:
+  subject:
+    namespaces:
+      matchLabels:
+        kubernetes.io/metadata.name: network-policy-conformance-gryffindor
+  egress:
+  # CIDR rules that test allow to specific IPs is done within the test by updating the CR
+  #- name: "allow-egress-to-specific-podIPs"
+  #  action: "Allow"
+  #  to:
+  #  - networks:
+  #    - luna-lovegood-0.IP
+  #    - cedric-diggory-0.IP
+  - name: "allow-egress-to-slytherin"
+    action: "Allow"
+    to:
+    - pods:
+        namespaceSelector:
+          matchLabels:
+            conformance-house: slytherin
+        podSelector:
+          matchLabels:
+            conformance-house: slytherin
+  - name: "deny-egress-to-internet"
+    action: "Deny"
+    to:
+    - networks:
+        - 0.0.0.0/0
+        - ::/0

--- a/conformance/tests/admin-network-policy-experimental-egress-rules.go
+++ b/conformance/tests/admin-network-policy-experimental-egress-rules.go
@@ -23,7 +23,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/utils/net"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/network-policy-api/apis/v1alpha1"
@@ -35,7 +34,6 @@ func init() {
 	ConformanceTests = append(ConformanceTests,
 		AdminNetworkPolicyEgressNamedPort,
 		AdminNetworkPolicyEgressNodePeers,
-		AdminNetworkPolicyEgressInlineCIDRPeers,
 	)
 }
 
@@ -139,132 +137,6 @@ var AdminNetworkPolicyEgressNodePeers = suite.ConformanceTest{
 			assert.True(t, success)
 			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "sctp",
 				serverPod.Status.PodIP, int32(9003), s.TimeoutConfig.RequestTimeout, false)
-			assert.True(t, success)
-		})
-	},
-}
-
-var AdminNetworkPolicyEgressInlineCIDRPeers = suite.ConformanceTest{
-	ShortName:   "AdminNetworkPolicyEgressInlineCIDRPeers",
-	Description: "Tests support for egress traffic to CIDR peers using admin network policy API based on a server and client model",
-	Features: []suite.SupportedFeature{
-		suite.SupportAdminNetworkPolicy,
-		suite.SupportAdminNetworkPolicyEgressInlineCIDRPeers,
-	},
-	Manifests: []string{"base/admin_network_policy/experimental-egress-selector-rules.yaml"},
-	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
-		ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
-		defer cancel()
-		// This test uses `node-and-cidr-as-peers-example` ANP
-		t.Run("Should support a 'deny-egress' rule policy for egress-cidr-peer", func(t *testing.T) {
-			// harry-potter-1 is our client pod in gryffindor namespace
-			// Let us pick a pod in ravenclaw namespace and try to connect, it won't work
-			// ensure egress is DENIED to 0.0.0.0/0 from gryffindor; egressRule at index2 should take effect
-			// luna-lovegood-0 is our server pod in ravenclaw namespace
-			serverPod := &v1.Pod{}
-			err := s.Client.Get(ctx, client.ObjectKey{
-				Namespace: "network-policy-conformance-ravenclaw",
-				Name:      "luna-lovegood-0",
-			}, serverPod)
-			require.NoErrorf(t, err, "unable to fetch the server pod")
-			success := kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "tcp",
-				serverPod.Status.PodIP, int32(80), s.TimeoutConfig.RequestTimeout, false)
-			assert.True(t, success)
-			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "udp",
-				serverPod.Status.PodIP, int32(53), s.TimeoutConfig.RequestTimeout, false)
-			assert.True(t, success)
-			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "sctp",
-				serverPod.Status.PodIP, int32(9003), s.TimeoutConfig.RequestTimeout, false)
-			assert.True(t, success)
-			// Let us pick a pod in hufflepuff namespace and try to connect, it won't work
-			// ensure egress is DENIED to 0.0.0.0/0 from gryffindor; egressRule at index2 should take effect
-			// cedric-diggory-0 is our server pod in hufflepuff namespace
-			serverPod = &v1.Pod{}
-			err = s.Client.Get(ctx, client.ObjectKey{
-				Namespace: "network-policy-conformance-hufflepuff",
-				Name:      "cedric-diggory-0",
-			}, serverPod)
-			require.NoErrorf(t, err, "unable to fetch the server pod")
-			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "tcp",
-				serverPod.Status.PodIP, int32(80), s.TimeoutConfig.RequestTimeout, false)
-			assert.True(t, success)
-			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "udp",
-				serverPod.Status.PodIP, int32(53), s.TimeoutConfig.RequestTimeout, false)
-			assert.True(t, success)
-			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "sctp",
-				serverPod.Status.PodIP, int32(9003), s.TimeoutConfig.RequestTimeout, false)
-			assert.True(t, success)
-		})
-		// To test allow CIDR rule, insert the following rule at index0
-		//- name: "allow-egress-to-specific-podIPs"
-		//  action: "Allow"
-		//  to:
-		//  - networks:
-		//	  - luna-lovegood-0.IP
-		//    - cedric-diggory-0.IP
-		t.Run("Should support an 'allow-egress' rule policy for egress-cidr-peer", func(t *testing.T) {
-			serverPodRavenclaw := &v1.Pod{}
-			err := s.Client.Get(ctx, client.ObjectKey{
-				Namespace: "network-policy-conformance-ravenclaw",
-				Name:      "luna-lovegood-0",
-			}, serverPodRavenclaw)
-			require.NoErrorf(t, err, "unable to fetch the server pod")
-			serverPodHufflepuff := &v1.Pod{}
-			err = s.Client.Get(ctx, client.ObjectKey{
-				Namespace: "network-policy-conformance-hufflepuff",
-				Name:      "cedric-diggory-0",
-			}, serverPodHufflepuff)
-			require.NoErrorf(t, err, "unable to fetch the server pod")
-			anp := &v1alpha1.AdminNetworkPolicy{}
-			err = s.Client.Get(ctx, client.ObjectKey{
-				Name: "node-and-cidr-as-peers-example",
-			}, anp)
-			require.NoErrorf(t, err, "unable to fetch the admin network policy")
-			mutate := anp.DeepCopy()
-			var mask string
-			if net.IsIPv4String(serverPodRavenclaw.Status.PodIP) {
-				mask = "/32"
-			} else {
-				mask = "/128"
-			}
-			// insert new rule at index0; append the rest of the rules in the node-and-cidr-as-peers-example
-			newRule := []v1alpha1.AdminNetworkPolicyEgressRule{
-				{
-					Name:   "allow-egress-to-specific-podIPs",
-					Action: "Allow",
-					To: []v1alpha1.AdminNetworkPolicyEgressPeer{
-						{
-							Networks: []v1alpha1.CIDR{
-								v1alpha1.CIDR(serverPodRavenclaw.Status.PodIP + mask),
-								v1alpha1.CIDR(serverPodHufflepuff.Status.PodIP + mask),
-							},
-						},
-					},
-				},
-			}
-			mutate.Spec.Egress = append(newRule, mutate.Spec.Egress...)
-			err = s.Client.Patch(ctx, mutate, client.MergeFrom(anp))
-			require.NoErrorf(t, err, "unable to patch the admin network policy")
-			// harry-potter-0 is our client pod in gryffindor namespace
-			// ensure egress is ALLOWED to luna-lovegood-0.IP and cedric-diggory-0.IP
-			// new egressRule at index0 should take effect
-			success := kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "tcp",
-				serverPodRavenclaw.Status.PodIP, int32(80), s.TimeoutConfig.RequestTimeout, true)
-			assert.True(t, success)
-			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "udp",
-				serverPodRavenclaw.Status.PodIP, int32(53), s.TimeoutConfig.RequestTimeout, true)
-			assert.True(t, success)
-			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "sctp",
-				serverPodRavenclaw.Status.PodIP, int32(9003), s.TimeoutConfig.RequestTimeout, true)
-			assert.True(t, success)
-			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "tcp",
-				serverPodHufflepuff.Status.PodIP, int32(80), s.TimeoutConfig.RequestTimeout, true)
-			assert.True(t, success)
-			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "udp",
-				serverPodHufflepuff.Status.PodIP, int32(53), s.TimeoutConfig.RequestTimeout, true)
-			assert.True(t, success)
-			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "sctp",
-				serverPodHufflepuff.Status.PodIP, int32(9003), s.TimeoutConfig.RequestTimeout, true)
 			assert.True(t, success)
 		})
 	},

--- a/conformance/tests/admin-network-policy-standard-egress-inline-cidr-rules.go
+++ b/conformance/tests/admin-network-policy-standard-egress-inline-cidr-rules.go
@@ -1,0 +1,214 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/utils/net"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/network-policy-api/apis/v1alpha1"
+	"sigs.k8s.io/network-policy-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/network-policy-api/conformance/utils/suite"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests,
+		AdminNetworkPolicyEgressInlineCIDRPeers,
+	)
+}
+
+var AdminNetworkPolicyEgressInlineCIDRPeers = suite.ConformanceTest{
+	ShortName:   "AdminNetworkPolicyEgressInlineCIDRPeers",
+	Description: "Tests support for egress traffic to CIDR peers using admin network policy API based on a server and client model",
+	Features: []suite.SupportedFeature{
+		suite.SupportAdminNetworkPolicy,
+	},
+	Manifests: []string{"base/admin_network_policy/standard-egress-inline-cidr-rules.yaml"},
+	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+		ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+		defer cancel()
+		// This test uses `inline-cidr-as-peers-example` ANP
+		t.Run("Should support a 'deny-egress' rule policy for egress-cidr-peer", func(t *testing.T) {
+			// harry-potter-1 is our client pod in gryffindor namespace
+			// Let us pick a pod in ravenclaw namespace and try to connect, it won't work
+			// ensure egress is DENIED to 0.0.0.0/0 from gryffindor; egressRule at index1 should take effect
+			// luna-lovegood-0 is our server pod in ravenclaw namespace
+			serverPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-ravenclaw",
+				Name:      "luna-lovegood-0",
+			}, serverPod)
+			require.NoErrorf(t, err, "unable to fetch the server pod")
+			success := kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "tcp",
+				serverPod.Status.PodIP, int32(80), s.TimeoutConfig.RequestTimeout, false)
+			assert.True(t, success)
+			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "udp",
+				serverPod.Status.PodIP, int32(53), s.TimeoutConfig.RequestTimeout, false)
+			assert.True(t, success)
+			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "sctp",
+				serverPod.Status.PodIP, int32(9003), s.TimeoutConfig.RequestTimeout, false)
+			assert.True(t, success)
+			// Let us pick a pod in hufflepuff namespace and try to connect, it won't work
+			// ensure egress is DENIED to 0.0.0.0/0 from gryffindor; egressRule at index1 should take effect
+			// cedric-diggory-0 is our server pod in hufflepuff namespace
+			serverPod = &v1.Pod{}
+			err = s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-hufflepuff",
+				Name:      "cedric-diggory-0",
+			}, serverPod)
+			require.NoErrorf(t, err, "unable to fetch the server pod")
+			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "tcp",
+				serverPod.Status.PodIP, int32(80), s.TimeoutConfig.RequestTimeout, false)
+			assert.True(t, success)
+			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "udp",
+				serverPod.Status.PodIP, int32(53), s.TimeoutConfig.RequestTimeout, false)
+			assert.True(t, success)
+			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "sctp",
+				serverPod.Status.PodIP, int32(9003), s.TimeoutConfig.RequestTimeout, false)
+			assert.True(t, success)
+			// Let us pick a pod in slytherin namespace and try to connect, it will work since we have a higher priority allow rule
+			// ensure traffic is allowed to slytherin; egressRule at index0 should take effect
+			// draco-malfoy-0 is our server pod in slytherin namespace
+			serverPod = &v1.Pod{}
+			err = s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-slytherin",
+				Name:      "draco-malfoy-0",
+			}, serverPod)
+			require.NoErrorf(t, err, "unable to fetch the server pod")
+			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "tcp",
+				serverPod.Status.PodIP, int32(80), s.TimeoutConfig.RequestTimeout, true)
+			assert.True(t, success)
+			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "udp",
+				serverPod.Status.PodIP, int32(53), s.TimeoutConfig.RequestTimeout, true)
+			assert.True(t, success)
+			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "sctp",
+				serverPod.Status.PodIP, int32(9003), s.TimeoutConfig.RequestTimeout, true)
+			assert.True(t, success)
+		})
+		// To test allow CIDR rule, insert the following rule at index0
+		//- name: "allow-egress-to-specific-podIPs"
+		//  action: "Allow"
+		//  to:
+		//  - networks:
+		//	  - luna-lovegood-0.IP
+		//    - cedric-diggory-0.IP
+		t.Run("Should support an 'allow-egress' rule policy for egress-cidr-peer", func(t *testing.T) {
+			serverPodRavenclaw := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-ravenclaw",
+				Name:      "luna-lovegood-0",
+			}, serverPodRavenclaw)
+			require.NoErrorf(t, err, "unable to fetch the server pod")
+			serverPodHufflepuff := &v1.Pod{}
+			err = s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-hufflepuff",
+				Name:      "cedric-diggory-0",
+			}, serverPodHufflepuff)
+			require.NoErrorf(t, err, "unable to fetch the server pod")
+			anp := &v1alpha1.AdminNetworkPolicy{}
+			err = s.Client.Get(ctx, client.ObjectKey{
+				Name: "inline-cidr-as-peers-example",
+			}, anp)
+			require.NoErrorf(t, err, "unable to fetch the admin network policy")
+			mutate := anp.DeepCopy()
+			var mask string
+			if net.IsIPv4String(serverPodRavenclaw.Status.PodIP) {
+				mask = "/32"
+			} else {
+				mask = "/128"
+			}
+			// insert new rule at index0; append the rest of the rules in the inline-cidr-as-peers-example
+			newRule := []v1alpha1.AdminNetworkPolicyEgressRule{
+				{
+					Name:   "allow-egress-to-specific-podIPs",
+					Action: "Allow",
+					To: []v1alpha1.AdminNetworkPolicyEgressPeer{
+						{
+							Networks: []v1alpha1.CIDR{
+								v1alpha1.CIDR(serverPodRavenclaw.Status.PodIP + mask),
+								v1alpha1.CIDR(serverPodHufflepuff.Status.PodIP + mask),
+							},
+						},
+					},
+				},
+			}
+			mutate.Spec.Egress = append(newRule, mutate.Spec.Egress...)
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(anp))
+			require.NoErrorf(t, err, "unable to patch the admin network policy")
+			// harry-potter-0 is our client pod in gryffindor namespace
+			// ensure egress is ALLOWED to luna-lovegood-0.IP and cedric-diggory-0.IP
+			// new egressRule at index0 should take effect
+			success := kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "tcp",
+				serverPodRavenclaw.Status.PodIP, int32(80), s.TimeoutConfig.RequestTimeout, true)
+			assert.True(t, success)
+			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "udp",
+				serverPodRavenclaw.Status.PodIP, int32(53), s.TimeoutConfig.RequestTimeout, true)
+			assert.True(t, success)
+			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "sctp",
+				serverPodRavenclaw.Status.PodIP, int32(9003), s.TimeoutConfig.RequestTimeout, true)
+			assert.True(t, success)
+			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "tcp",
+				serverPodHufflepuff.Status.PodIP, int32(80), s.TimeoutConfig.RequestTimeout, true)
+			assert.True(t, success)
+			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "udp",
+				serverPodHufflepuff.Status.PodIP, int32(53), s.TimeoutConfig.RequestTimeout, true)
+			assert.True(t, success)
+			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "sctp",
+				serverPodHufflepuff.Status.PodIP, int32(9003), s.TimeoutConfig.RequestTimeout, true)
+			assert.True(t, success)
+			// ensure other pods are still unreachable: luna-lovegood-1.IP and cedric-diggory-1.IP
+			// deny at egress rule index2 should kick in
+			err = s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-ravenclaw",
+				Name:      "luna-lovegood-1",
+			}, serverPodRavenclaw)
+			require.NoErrorf(t, err, "unable to fetch the server pod")
+			err = s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-hufflepuff",
+				Name:      "cedric-diggory-1",
+			}, serverPodHufflepuff)
+			require.NoErrorf(t, err, "unable to fetch the server pod")
+			// harry-potter-0 is our client pod in gryffindor namespace
+			// ensure egress is ALLOWED to luna-lovegood-0.IP and cedric-diggory-0.IP
+			// new egressRule at index0 should take effect
+			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "tcp",
+				serverPodRavenclaw.Status.PodIP, int32(80), s.TimeoutConfig.RequestTimeout, false)
+			assert.True(t, success)
+			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "udp",
+				serverPodRavenclaw.Status.PodIP, int32(53), s.TimeoutConfig.RequestTimeout, false)
+			assert.True(t, success)
+			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "sctp",
+				serverPodRavenclaw.Status.PodIP, int32(9003), s.TimeoutConfig.RequestTimeout, false)
+			assert.True(t, success)
+			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "tcp",
+				serverPodHufflepuff.Status.PodIP, int32(80), s.TimeoutConfig.RequestTimeout, false)
+			assert.True(t, success)
+			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "udp",
+				serverPodHufflepuff.Status.PodIP, int32(53), s.TimeoutConfig.RequestTimeout, false)
+			assert.True(t, success)
+			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "sctp",
+				serverPodHufflepuff.Status.PodIP, int32(9003), s.TimeoutConfig.RequestTimeout, false)
+			assert.True(t, success)
+		})
+	},
+}

--- a/conformance/tests/baseline-admin-network-policy-experimental-egress-rules.go
+++ b/conformance/tests/baseline-admin-network-policy-experimental-egress-rules.go
@@ -23,7 +23,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/utils/net"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/network-policy-api/apis/v1alpha1"
@@ -35,7 +34,6 @@ func init() {
 	ConformanceTests = append(ConformanceTests,
 		BaselineAdminNetworkPolicyEgressNamedPort,
 		BaselineAdminNetworkPolicyEgressNodePeers,
-		BaselineAdminNetworkPolicyEgressInlineCIDRPeers,
 	)
 }
 
@@ -130,131 +128,6 @@ var BaselineAdminNetworkPolicyEgressNodePeers = suite.ConformanceTest{
 			assert.True(t, success)
 			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "sctp",
 				serverPod.Status.PodIP, int32(9003), s.TimeoutConfig.RequestTimeout, false)
-			assert.True(t, success)
-		})
-	},
-}
-
-var BaselineAdminNetworkPolicyEgressInlineCIDRPeers = suite.ConformanceTest{
-	ShortName:   "BaselineAdminNetworkPolicyEgressInlineCIDRPeers",
-	Description: "Tests support for egress traffic to CIDR peers using baseline admin network policy API based on a server and client model",
-	Features: []suite.SupportedFeature{
-		suite.SupportBaselineAdminNetworkPolicy,
-		suite.SupportBaselineAdminNetworkPolicyEgressInlineCIDRPeers,
-	},
-	Manifests: []string{"base/baseline_admin_network_policy/experimental-egress-selector-rules.yaml"},
-	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
-		ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
-		defer cancel()
-		t.Run("Should support a 'deny-egress' rule policy for egress-cidr-peer", func(t *testing.T) {
-			// harry-potter-1 is our client pod in gryffindor namespace
-			// Let us pick a pod in ravenclaw namespace and try to connect, it won't work
-			// ensure egress is DENIED to 0.0.0.0/0 from gryffindor; egressRule at index1 should take effect
-			// luna-lovegood-0 is our server pod in ravenclaw namespace
-			serverPod := &v1.Pod{}
-			err := s.Client.Get(ctx, client.ObjectKey{
-				Namespace: "network-policy-conformance-ravenclaw",
-				Name:      "luna-lovegood-0",
-			}, serverPod)
-			require.NoErrorf(t, err, "unable to fetch the server pod")
-			success := kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "tcp",
-				serverPod.Status.PodIP, int32(80), s.TimeoutConfig.RequestTimeout, false)
-			assert.True(t, success)
-			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "udp",
-				serverPod.Status.PodIP, int32(53), s.TimeoutConfig.RequestTimeout, false)
-			assert.True(t, success)
-			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "sctp",
-				serverPod.Status.PodIP, int32(9003), s.TimeoutConfig.RequestTimeout, false)
-			assert.True(t, success)
-			// Let us pick a pod in hufflepuff namespace and try to connect, it won't work
-			// ensure egress is DENIED to 0.0.0.0/0 from gryffindor; egressRule at index2 should take effect
-			// cedric-diggory-0 is our server pod in hufflepuff namespace
-			serverPod = &v1.Pod{}
-			err = s.Client.Get(ctx, client.ObjectKey{
-				Namespace: "network-policy-conformance-hufflepuff",
-				Name:      "cedric-diggory-0",
-			}, serverPod)
-			require.NoErrorf(t, err, "unable to fetch the server pod")
-			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "tcp",
-				serverPod.Status.PodIP, int32(80), s.TimeoutConfig.RequestTimeout, false)
-			assert.True(t, success)
-			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "udp",
-				serverPod.Status.PodIP, int32(53), s.TimeoutConfig.RequestTimeout, false)
-			assert.True(t, success)
-			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "sctp",
-				serverPod.Status.PodIP, int32(9003), s.TimeoutConfig.RequestTimeout, false)
-			assert.True(t, success)
-		})
-		// To test allow CIDR rule, insert the following rule at index0
-		//- name: "allow-egress-to-specific-podIPs"
-		//  action: "Allow"
-		//  to:
-		//  - networks:
-		//	  - luna-lovegood-0.IP
-		//    - cedric-diggory-0.IP
-		t.Run("Should support an 'allow-egress' rule policy for egress-cidr-peer", func(t *testing.T) {
-			serverPodRavenclaw := &v1.Pod{}
-			err := s.Client.Get(ctx, client.ObjectKey{
-				Namespace: "network-policy-conformance-ravenclaw",
-				Name:      "luna-lovegood-0",
-			}, serverPodRavenclaw)
-			require.NoErrorf(t, err, "unable to fetch the server pod")
-			serverPodHufflepuff := &v1.Pod{}
-			err = s.Client.Get(ctx, client.ObjectKey{
-				Namespace: "network-policy-conformance-hufflepuff",
-				Name:      "cedric-diggory-0",
-			}, serverPodHufflepuff)
-			require.NoErrorf(t, err, "unable to fetch the server pod")
-			banp := &v1alpha1.BaselineAdminNetworkPolicy{}
-			err = s.Client.Get(ctx, client.ObjectKey{
-				Name: "default",
-			}, banp)
-			require.NoErrorf(t, err, "unable to fetch the baseline admin network policy")
-			mutate := banp.DeepCopy()
-			var mask string
-			if net.IsIPv4String(serverPodRavenclaw.Status.PodIP) {
-				mask = "/32"
-			} else {
-				mask = "/128"
-			}
-			// insert new rule at index0; append the rest of the rules in the default BANP
-			newRule := []v1alpha1.BaselineAdminNetworkPolicyEgressRule{
-				{
-					Name:   "allow-egress-to-specific-podIPs",
-					Action: "Allow",
-					To: []v1alpha1.BaselineAdminNetworkPolicyEgressPeer{
-						{
-							Networks: []v1alpha1.CIDR{
-								v1alpha1.CIDR(serverPodRavenclaw.Status.PodIP + mask),
-								v1alpha1.CIDR(serverPodHufflepuff.Status.PodIP + mask),
-							},
-						},
-					},
-				},
-			}
-			mutate.Spec.Egress = append(newRule, mutate.Spec.Egress...)
-			err = s.Client.Patch(ctx, mutate, client.MergeFrom(banp))
-			require.NoErrorf(t, err, "unable to patch the baseline admin network policy")
-			// harry-potter-0 is our client pod in gryffindor namespace
-			// ensure egress is ALLOWED to luna-lovegood-0.IP and cedric-diggory-0.IP
-			// new egressRule at index0 should take effect
-			success := kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "tcp",
-				serverPodRavenclaw.Status.PodIP, int32(80), s.TimeoutConfig.RequestTimeout, true)
-			assert.True(t, success)
-			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "udp",
-				serverPodRavenclaw.Status.PodIP, int32(53), s.TimeoutConfig.RequestTimeout, true)
-			assert.True(t, success)
-			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "sctp",
-				serverPodRavenclaw.Status.PodIP, int32(9003), s.TimeoutConfig.RequestTimeout, true)
-			assert.True(t, success)
-			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "tcp",
-				serverPodHufflepuff.Status.PodIP, int32(80), s.TimeoutConfig.RequestTimeout, true)
-			assert.True(t, success)
-			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "udp",
-				serverPodHufflepuff.Status.PodIP, int32(53), s.TimeoutConfig.RequestTimeout, true)
-			assert.True(t, success)
-			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "sctp",
-				serverPodHufflepuff.Status.PodIP, int32(9003), s.TimeoutConfig.RequestTimeout, true)
 			assert.True(t, success)
 		})
 	},

--- a/conformance/tests/baseline-admin-network-policy-standard-egress-inline-cidr-rules.go
+++ b/conformance/tests/baseline-admin-network-policy-standard-egress-inline-cidr-rules.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/utils/net"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/network-policy-api/apis/v1alpha1"
+	"sigs.k8s.io/network-policy-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/network-policy-api/conformance/utils/suite"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests,
+		BaselineAdminNetworkPolicyEgressInlineCIDRPeers,
+	)
+}
+
+var BaselineAdminNetworkPolicyEgressInlineCIDRPeers = suite.ConformanceTest{
+	ShortName:   "BaselineAdminNetworkPolicyEgressInlineCIDRPeers",
+	Description: "Tests support for egress traffic to CIDR peers using baseline admin network policy API based on a server and client model",
+	Features: []suite.SupportedFeature{
+		suite.SupportBaselineAdminNetworkPolicy,
+	},
+	Manifests: []string{"base/baseline_admin_network_policy/standard-egress-inline-cidr-rules.yaml"},
+	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+		ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
+		defer cancel()
+		t.Run("Should support a 'deny-egress' rule policy for egress-cidr-peer", func(t *testing.T) {
+			// harry-potter-1 is our client pod in gryffindor namespace
+			// Let us pick a pod in ravenclaw namespace and try to connect, it won't work
+			// ensure egress is DENIED to 0.0.0.0/0 from gryffindor; egressRule at index1 should take effect
+			// luna-lovegood-0 is our server pod in ravenclaw namespace
+			serverPod := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-ravenclaw",
+				Name:      "luna-lovegood-0",
+			}, serverPod)
+			require.NoErrorf(t, err, "unable to fetch the server pod")
+			success := kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "tcp",
+				serverPod.Status.PodIP, int32(80), s.TimeoutConfig.RequestTimeout, false)
+			assert.True(t, success)
+			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "udp",
+				serverPod.Status.PodIP, int32(53), s.TimeoutConfig.RequestTimeout, false)
+			assert.True(t, success)
+			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "sctp",
+				serverPod.Status.PodIP, int32(9003), s.TimeoutConfig.RequestTimeout, false)
+			assert.True(t, success)
+			// Let us pick a pod in hufflepuff namespace and try to connect, it won't work
+			// ensure egress is DENIED to 0.0.0.0/0 from gryffindor; egressRule at index1 should take effect
+			// cedric-diggory-0 is our server pod in hufflepuff namespace
+			serverPod = &v1.Pod{}
+			err = s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-hufflepuff",
+				Name:      "cedric-diggory-0",
+			}, serverPod)
+			require.NoErrorf(t, err, "unable to fetch the server pod")
+			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "tcp",
+				serverPod.Status.PodIP, int32(80), s.TimeoutConfig.RequestTimeout, false)
+			assert.True(t, success)
+			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "udp",
+				serverPod.Status.PodIP, int32(53), s.TimeoutConfig.RequestTimeout, false)
+			assert.True(t, success)
+			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "sctp",
+				serverPod.Status.PodIP, int32(9003), s.TimeoutConfig.RequestTimeout, false)
+			assert.True(t, success)
+			// Let us pick a pod in slytherin namespace and try to connect, it will work since we have a higher priority allow rule
+			// ensure traffic is allowed to slytherin; egressRule at index0 should take effect
+			// draco-malfoy-0 is our server pod in slytherin namespace
+			serverPod = &v1.Pod{}
+			err = s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-slytherin",
+				Name:      "draco-malfoy-0",
+			}, serverPod)
+			require.NoErrorf(t, err, "unable to fetch the server pod")
+			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "tcp",
+				serverPod.Status.PodIP, int32(80), s.TimeoutConfig.RequestTimeout, true)
+			assert.True(t, success)
+			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "udp",
+				serverPod.Status.PodIP, int32(53), s.TimeoutConfig.RequestTimeout, true)
+			assert.True(t, success)
+			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "sctp",
+				serverPod.Status.PodIP, int32(9003), s.TimeoutConfig.RequestTimeout, true)
+			assert.True(t, success)
+		})
+		// To test allow CIDR rule, insert the following rule at index0
+		//- name: "allow-egress-to-specific-podIPs"
+		//  action: "Allow"
+		//  to:
+		//  - networks:
+		//	  - luna-lovegood-0.IP
+		//    - cedric-diggory-0.IP
+		t.Run("Should support an 'allow-egress' rule policy for egress-cidr-peer", func(t *testing.T) {
+			serverPodRavenclaw := &v1.Pod{}
+			err := s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-ravenclaw",
+				Name:      "luna-lovegood-0",
+			}, serverPodRavenclaw)
+			require.NoErrorf(t, err, "unable to fetch the server pod")
+			serverPodHufflepuff := &v1.Pod{}
+			err = s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-hufflepuff",
+				Name:      "cedric-diggory-0",
+			}, serverPodHufflepuff)
+			require.NoErrorf(t, err, "unable to fetch the server pod")
+			banp := &v1alpha1.BaselineAdminNetworkPolicy{}
+			err = s.Client.Get(ctx, client.ObjectKey{
+				Name: "default",
+			}, banp)
+			require.NoErrorf(t, err, "unable to fetch the baseline admin network policy")
+			mutate := banp.DeepCopy()
+			var mask string
+			if net.IsIPv4String(serverPodRavenclaw.Status.PodIP) {
+				mask = "/32"
+			} else {
+				mask = "/128"
+			}
+			// insert new rule at index0; append the rest of the rules in the default BANP
+			newRule := []v1alpha1.BaselineAdminNetworkPolicyEgressRule{
+				{
+					Name:   "allow-egress-to-specific-podIPs",
+					Action: "Allow",
+					To: []v1alpha1.BaselineAdminNetworkPolicyEgressPeer{
+						{
+							Networks: []v1alpha1.CIDR{
+								v1alpha1.CIDR(serverPodRavenclaw.Status.PodIP + mask),
+								v1alpha1.CIDR(serverPodHufflepuff.Status.PodIP + mask),
+							},
+						},
+					},
+				},
+			}
+			mutate.Spec.Egress = append(newRule, mutate.Spec.Egress...)
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(banp))
+			require.NoErrorf(t, err, "unable to patch the baseline admin network policy")
+			// harry-potter-0 is our client pod in gryffindor namespace
+			// ensure egress is ALLOWED to luna-lovegood-0.IP and cedric-diggory-0.IP
+			// new egressRule at index0 should take effect
+			success := kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "tcp",
+				serverPodRavenclaw.Status.PodIP, int32(80), s.TimeoutConfig.RequestTimeout, true)
+			assert.True(t, success)
+			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "udp",
+				serverPodRavenclaw.Status.PodIP, int32(53), s.TimeoutConfig.RequestTimeout, true)
+			assert.True(t, success)
+			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "sctp",
+				serverPodRavenclaw.Status.PodIP, int32(9003), s.TimeoutConfig.RequestTimeout, true)
+			assert.True(t, success)
+			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "tcp",
+				serverPodHufflepuff.Status.PodIP, int32(80), s.TimeoutConfig.RequestTimeout, true)
+			assert.True(t, success)
+			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "udp",
+				serverPodHufflepuff.Status.PodIP, int32(53), s.TimeoutConfig.RequestTimeout, true)
+			assert.True(t, success)
+			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "sctp",
+				serverPodHufflepuff.Status.PodIP, int32(9003), s.TimeoutConfig.RequestTimeout, true)
+			assert.True(t, success)
+			// ensure other pods are still unreachable: luna-lovegood-1.IP and cedric-diggory-1.IP
+			// deny at egress rule index2 should kick in
+			err = s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-ravenclaw",
+				Name:      "luna-lovegood-1",
+			}, serverPodRavenclaw)
+			require.NoErrorf(t, err, "unable to fetch the server pod")
+			err = s.Client.Get(ctx, client.ObjectKey{
+				Namespace: "network-policy-conformance-hufflepuff",
+				Name:      "cedric-diggory-1",
+			}, serverPodHufflepuff)
+			require.NoErrorf(t, err, "unable to fetch the server pod")
+			// harry-potter-0 is our client pod in gryffindor namespace
+			// ensure egress is ALLOWED to luna-lovegood-0.IP and cedric-diggory-0.IP
+			// new egressRule at index0 should take effect
+			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "tcp",
+				serverPodRavenclaw.Status.PodIP, int32(80), s.TimeoutConfig.RequestTimeout, false)
+			assert.True(t, success)
+			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "udp",
+				serverPodRavenclaw.Status.PodIP, int32(53), s.TimeoutConfig.RequestTimeout, false)
+			assert.True(t, success)
+			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "sctp",
+				serverPodRavenclaw.Status.PodIP, int32(9003), s.TimeoutConfig.RequestTimeout, false)
+			assert.True(t, success)
+			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "tcp",
+				serverPodHufflepuff.Status.PodIP, int32(80), s.TimeoutConfig.RequestTimeout, false)
+			assert.True(t, success)
+			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "udp",
+				serverPodHufflepuff.Status.PodIP, int32(53), s.TimeoutConfig.RequestTimeout, false)
+			assert.True(t, success)
+			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "sctp",
+				serverPodHufflepuff.Status.PodIP, int32(9003), s.TimeoutConfig.RequestTimeout, false)
+			assert.True(t, success)
+		})
+	},
+}

--- a/conformance/utils/suite/conformance_profiles.go
+++ b/conformance/utils/suite/conformance_profiles.go
@@ -62,7 +62,6 @@ var (
 		ExperimentalFeatures: sets.New(
 			SupportAdminNetworkPolicyNamedPorts,
 			SupportAdminNetworkPolicyEgressNodePeers,
-			SupportAdminNetworkPolicyEgressInlineCIDRPeers,
 		),
 	}
 
@@ -75,7 +74,6 @@ var (
 		ExperimentalFeatures: sets.New(
 			SupportBaselineAdminNetworkPolicyNamedPorts,
 			SupportBaselineAdminNetworkPolicyEgressNodePeers,
-			SupportBaselineAdminNetworkPolicyEgressInlineCIDRPeers,
 		),
 	}
 )

--- a/conformance/utils/suite/features.go
+++ b/conformance/utils/suite/features.go
@@ -49,14 +49,12 @@ var StandardFeatures = sets.New(
 // -----------------------------------------------------------------------------
 
 const (
-	// This option indicates AdminNetworkPolicy's NamedPorts, EgressNodePeers, EgressInlineCIDRPeers
+	// This option indicates AdminNetworkPolicy's NamedPorts, EgressNodePeers
 	// fall under the extended test conformance.
-	SupportAdminNetworkPolicyNamedPorts                    SupportedFeature = "AdminNetworkPolicyNamedPorts"
-	SupportAdminNetworkPolicyEgressNodePeers               SupportedFeature = "AdminNetworkPolicyEgressNodePeers"
-	SupportAdminNetworkPolicyEgressInlineCIDRPeers         SupportedFeature = "AdminNetworkPolicyEgressInlineCIDRPeers"
-	SupportBaselineAdminNetworkPolicyNamedPorts            SupportedFeature = "BaselineAdminNetworkPolicyNamedPorts"
-	SupportBaselineAdminNetworkPolicyEgressNodePeers       SupportedFeature = "BaselineAdminNetworkPolicyEgressNodePeers"
-	SupportBaselineAdminNetworkPolicyEgressInlineCIDRPeers SupportedFeature = "BaselineAdminNetworkPolicyEgressInlineCIDRPeers"
+	SupportAdminNetworkPolicyNamedPorts              SupportedFeature = "AdminNetworkPolicyNamedPorts"
+	SupportAdminNetworkPolicyEgressNodePeers         SupportedFeature = "AdminNetworkPolicyEgressNodePeers"
+	SupportBaselineAdminNetworkPolicyNamedPorts      SupportedFeature = "BaselineAdminNetworkPolicyNamedPorts"
+	SupportBaselineAdminNetworkPolicyEgressNodePeers SupportedFeature = "BaselineAdminNetworkPolicyEgressNodePeers"
 )
 
 // ExperimentalFeatures are newer, unstable features that are not part of the standard channel.
@@ -64,10 +62,8 @@ const (
 var ExperimentalFeatures = sets.New(
 	SupportAdminNetworkPolicyNamedPorts,
 	SupportAdminNetworkPolicyEgressNodePeers,
-	SupportAdminNetworkPolicyEgressInlineCIDRPeers,
 	SupportBaselineAdminNetworkPolicyNamedPorts,
 	SupportBaselineAdminNetworkPolicyEgressNodePeers,
-	SupportBaselineAdminNetworkPolicyEgressInlineCIDRPeers,
 ).Insert(StandardFeatures.UnsortedList()...)
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
- We have three implementations: ovn-k, calico and kube-network-policies implementing this field, its been a year almost since we added networks. Time to graduate this to standard.
- This was discussed and agreed at KubeCon EU

Depends on https://github.com/kubernetes-sigs/network-policy-api/pull/284 going in first to avoid conflicts.

~TODO: Think a bit more into maybe splitting that experimental CRD to have separate tests for nodes and networks?~ This is done.
```
go test  -v ./conformance -run TestConformanceProfiles -args --conformance-profiles=AdminNetworkPolicy,BaselineAdminNetworkPolicy --organization=ovn-org -project=ovn-kubernetes -url=blah -version=0.1.1 -contact=surya -additional-info=blah -supported-features=AdminNetworkPolicyEgressNodePeers,BaselineAdminNetworkPolicyEgressNodePeers,AdminNetworkPolicyNamedPorts,BaselineAdminNetworkPolicyNamedPorts
```

Closes #259 