### PR TITLE
Cut release v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [v0.1.0](#v010)
 - [v0.1.1](#v011)
+- [v0.1.7](#v017)
 
 # v0.1.0
 
@@ -34,5 +35,32 @@ Additionally it includes many conformance test updates and fixes:
 - Variable renaming and comment improvements
 - Increased default timeout
 - Removal of K8s.io/kubernetes dependency
+
+Please check out the [network-policy-api website](https://network-policy-api.sigs.k8s.io/) for more information.
+
+# v0.1.7
+
+API Version: v1alpha1
+
+This is a patch release of the network-policy-api. It includes two
+main resources geared towards cluster admins:
+
+- AdminNetworkPolicy
+- BaselineAdminNetworkPolicy
+
+The new aspects of the API being released here since v0.1.1 that are worth highlighting include:
+
+- A new type of egress peer `networks` is supported to be able to express CIDR ranges as peers
+- An experimental egress peer `nodes` is supported to be able to express Kubernetes nodes as peers
+- An experimental egress peer `domainNames` is supported to be able to express FQDNs as peers
+- Docs text change around calling out that host-networked pods are not selected as part of subject or peers
+- More conformance tests specially for the new fields
+
+Another noteworthy change is the removal of `sameLabels` and `notSameLabels` fields from the API.
+Originally these fields were added to be able to express a form of tenancy that was relative to
+the selected subject of the policy. Given the selection based on sameness and not-sameness of labels
+could compound to many possible ways of expressing relations that would exceed cardinality, the
+community is working on a better API proposal for tenancy. See [NPEP-122](https://github.com/kubernetes-sigs/network-policy-api/pull/178)
+for more details.
 
 Please check out the [network-policy-api website](https://network-policy-api.sigs.k8s.io/) for more information.

--- a/config/crd/experimental/policy.networking.k8s.io_adminnetworkpolicies.yaml
+++ b/config/crd/experimental/policy.networking.k8s.io_adminnetworkpolicies.yaml
@@ -2,8 +2,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/network-policy-api/pull/30
-    policy.networking.k8s.io/bundle-version: v0.1.1
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/network-policy-api/pull/300
+    policy.networking.k8s.io/bundle-version: v0.1.7
     policy.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: adminnetworkpolicies.policy.networking.k8s.io

--- a/config/crd/experimental/policy.networking.k8s.io_baselineadminnetworkpolicies.yaml
+++ b/config/crd/experimental/policy.networking.k8s.io_baselineadminnetworkpolicies.yaml
@@ -2,8 +2,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/network-policy-api/pull/30
-    policy.networking.k8s.io/bundle-version: v0.1.1
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/network-policy-api/pull/300
+    policy.networking.k8s.io/bundle-version: v0.1.7
     policy.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: baselineadminnetworkpolicies.policy.networking.k8s.io

--- a/config/crd/standard/policy.networking.k8s.io_adminnetworkpolicies.yaml
+++ b/config/crd/standard/policy.networking.k8s.io_adminnetworkpolicies.yaml
@@ -2,8 +2,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/network-policy-api/pull/30
-    policy.networking.k8s.io/bundle-version: v0.1.1
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/network-policy-api/pull/300
+    policy.networking.k8s.io/bundle-version: v0.1.7
     policy.networking.k8s.io/channel: standard
   creationTimestamp: null
   name: adminnetworkpolicies.policy.networking.k8s.io

--- a/config/crd/standard/policy.networking.k8s.io_baselineadminnetworkpolicies.yaml
+++ b/config/crd/standard/policy.networking.k8s.io_baselineadminnetworkpolicies.yaml
@@ -2,8 +2,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/network-policy-api/pull/30
-    policy.networking.k8s.io/bundle-version: v0.1.1
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/network-policy-api/pull/300
+    policy.networking.k8s.io/bundle-version: v0.1.7
     policy.networking.k8s.io/channel: standard
   creationTimestamp: null
   name: baselineadminnetworkpolicies.policy.networking.k8s.io

--- a/pkg/generator/main.go
+++ b/pkg/generator/main.go
@@ -32,8 +32,8 @@ const (
 	channelAnnotation       = "policy.networking.k8s.io/channel"
 
 	// These values must be updated during the release process
-	bundleVersion = "v0.1.1"
-	approvalLink  = "https://github.com/kubernetes-sigs/network-policy-api/pull/30"
+	bundleVersion = "v0.1.7"
+	approvalLink  = "https://github.com/kubernetes-sigs/network-policy-api/pull/300"
 )
 
 var standardKinds = map[string]bool{


### PR DESCRIPTION
Given that we got API approval https://github.com/kubernetes-sigs/network-policy-api/pull/300 let's cut the release.

Only remaining change we need is: https://github.com/kubernetes-sigs/network-policy-api/pull/303