### PR TITLE
API: reduce priority range from 1000 to 500

### DIFF
--- a/apis/v1alpha2/clusternetworkpolicy_types.go
+++ b/apis/v1alpha2/clusternetworkpolicy_types.go
@@ -80,7 +80,7 @@ type ClusterNetworkPolicySpec struct {
 	// all pods can communicate with each other.
 	Tier Tier `json:"tier"`
 
-	// Priority is a value from 0 to 1000 indicating the precedence of
+	// Priority is a value from 0 to 500 indicating the precedence of
 	// the policy within its tier. Policies with lower priority values have
 	// higher precedence, and are checked before policies with higher priority
 	// values in the same tier. All Admin tier rules have higher precedence than
@@ -94,7 +94,7 @@ type ClusterNetworkPolicySpec struct {
 	// values in cases where ambiguity would be unacceptable.
 	//
 	// +kubebuilder:validation:Minimum=0
-	// +kubebuilder:validation:Maximum=1000
+	// +kubebuilder:validation:Maximum=500
 	Priority int32 `json:"priority"`
 
 	// Subject defines the pods to which this ClusterNetworkPolicy applies.

--- a/config/crd/experimental/policy.networking.k8s.io_clusternetworkpolicies.yaml
+++ b/config/crd/experimental/policy.networking.k8s.io_clusternetworkpolicies.yaml
@@ -791,7 +791,7 @@ spec:
                 type: array
               priority:
                 description: |-
-                  Priority is a value from 0 to 1000 indicating the precedence of
+                  Priority is a value from 0 to 500 indicating the precedence of
                   the policy within its tier. Policies with lower priority values have
                   higher precedence, and are checked before policies with higher priority
                   values in the same tier. All Admin tier rules have higher precedence than
@@ -804,7 +804,7 @@ spec:
                   match many connections, and ensure that policies have unique priority
                   values in cases where ambiguity would be unacceptable.
                 format: int32
-                maximum: 1000
+                maximum: 500
                 minimum: 0
                 type: integer
               subject:

--- a/config/crd/standard/policy.networking.k8s.io_clusternetworkpolicies.yaml
+++ b/config/crd/standard/policy.networking.k8s.io_clusternetworkpolicies.yaml
@@ -677,7 +677,7 @@ spec:
                 type: array
               priority:
                 description: |-
-                  Priority is a value from 0 to 1000 indicating the precedence of
+                  Priority is a value from 0 to 500 indicating the precedence of
                   the policy within its tier. Policies with lower priority values have
                   higher precedence, and are checked before policies with higher priority
                   values in the same tier. All Admin tier rules have higher precedence than
@@ -690,7 +690,7 @@ spec:
                   match many connections, and ensure that policies have unique priority
                   values in cases where ambiguity would be unacceptable.
                 format: int32
-                maximum: 1000
+                maximum: 500
                 minimum: 0
                 type: integer
               subject:


### PR DESCRIPTION
This seemingly-minor change means that a full policy tier can be packed into a 16-bit integer (because 500 * 100 < 2^16). As written, the spec could allow up to 100,000 rules per tier, which unfortunately needs 17 bits at a worst case.