### PR TITLE
Fix validation of CIDR fields

### DIFF
--- a/apis/v1alpha1/shared_types.go
+++ b/apis/v1alpha1/shared_types.go
@@ -134,6 +134,6 @@ type AdminNetworkPolicyIngressPeer struct {
 }
 
 // CIDR is an IP address range in CIDR notation (for example, "10.0.0.0/8" or "fd00::/8").
-// +kubebuilder:validation:XValidation:rule="isCIDR(self)",message="Invalid CIDR format provided"
+// +kubebuilder:validation:XValidation:rule="isCIDR(self) && cidr(self) == cidr(self).masked()",message="Invalid CIDR format provided"
 // +kubebuilder:validation:MaxLength=43
 type CIDR string

--- a/apis/v1alpha2/clusternetworkpolicy_types.go
+++ b/apis/v1alpha2/clusternetworkpolicy_types.go
@@ -528,7 +528,7 @@ type PortRange struct {
 // CIDR is an IP address range in CIDR notation
 // (for example, "10.0.0.0/8" or "fd00::/8").
 //
-// +kubebuilder:validation:XValidation:rule="isCIDR(self)",message="Invalid CIDR format provided"
+// +kubebuilder:validation:XValidation:rule="isCIDR(self) && cidr(self) == cidr(self).masked()",message="Invalid CIDR format provided"
 // +kubebuilder:validation:MaxLength=43
 type CIDR string
 

--- a/config/crd/experimental/policy.networking.k8s.io_clusternetworkpolicies.yaml
+++ b/config/crd/experimental/policy.networking.k8s.io_clusternetworkpolicies.yaml
@@ -390,7 +390,7 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: Invalid CIDR format provided
-                                rule: isCIDR(self)
+                                rule: isCIDR(self) && cidr(self) == cidr(self).masked()
                             maxItems: 25
                             minItems: 1
                             type: array

--- a/config/crd/standard/policy.networking.k8s.io_clusternetworkpolicies.yaml
+++ b/config/crd/standard/policy.networking.k8s.io_clusternetworkpolicies.yaml
@@ -352,7 +352,7 @@ spec:
                               type: string
                               x-kubernetes-validations:
                               - message: Invalid CIDR format provided
-                                rule: isCIDR(self)
+                                rule: isCIDR(self) && cidr(self) == cidr(self).masked()
                             maxItems: 25
                             minItems: 1
                             type: array


### PR DESCRIPTION
re https://github.com/kubernetes/kubernetes/issues/134224; `isCIDR()` allows both "mask-like" CIDRs ("192.168.0.0/24") and "address-like" CIDRs ("192.168.0.5/24"). We only want the former.

(If `isCIDR()` gets changed, then the extra clause here will just be a no-op, but we'll have better backward-compatibility this way.)