### PR TITLE
Change MaxItems from 100 to 25

### DIFF
--- a/apis/v1alpha2/clusternetworkpolicy_types.go
+++ b/apis/v1alpha2/clusternetworkpolicy_types.go
@@ -110,7 +110,7 @@ type ClusterNetworkPolicySpec struct {
 	// CNPs with no ingress rules do not affect ingress traffic.
 	//
 	// +optional
-	// +kubebuilder:validation:MaxItems=100
+	// +kubebuilder:validation:MaxItems=25
 	Ingress []ClusterNetworkPolicyIngressRule `json:"ingress,omitempty"`
 
 	// Egress is the list of Egress rules to be applied to the selected pods.
@@ -123,7 +123,7 @@ type ClusterNetworkPolicySpec struct {
 	// CNPs with no egress rules do not affect egress traffic.
 	//
 	// +optional
-	// +kubebuilder:validation:MaxItems=100
+	// +kubebuilder:validation:MaxItems=25
 	Egress []ClusterNetworkPolicyEgressRule `json:"egress,omitempty"`
 }
 
@@ -199,7 +199,7 @@ type ClusterNetworkPolicyIngressRule struct {
 	// This field must be defined and contain at least one item.
 	//
 	// +kubebuilder:validation:MinItems=1
-	// +kubebuilder:validation:MaxItems=100
+	// +kubebuilder:validation:MaxItems=25
 	From []ClusterNetworkPolicyIngressPeer `json:"from"`
 
 	// Ports allows for matching traffic based on port and protocols.
@@ -210,7 +210,7 @@ type ClusterNetworkPolicyIngressRule struct {
 	//
 	// +optional
 	// +kubebuilder:validation:MinItems=1
-	// +kubebuilder:validation:MaxItems=100
+	// +kubebuilder:validation:MaxItems=25
 	Ports *[]ClusterNetworkPolicyPort `json:"ports,omitempty"`
 }
 
@@ -251,7 +251,7 @@ type ClusterNetworkPolicyEgressRule struct {
 	// This field must be defined and contain at least one item.
 	//
 	// +kubebuilder:validation:MinItems=1
-	// +kubebuilder:validation:MaxItems=100
+	// +kubebuilder:validation:MaxItems=25
 	To []ClusterNetworkPolicyEgressPeer `json:"to"`
 
 	// Ports allows for matching traffic based on port and protocols.
@@ -260,7 +260,7 @@ type ClusterNetworkPolicyEgressRule struct {
 	//
 	// +optional
 	// +kubebuilder:validation:MinItems=1
-	// +kubebuilder:validation:MaxItems=100
+	// +kubebuilder:validation:MaxItems=25
 	Ports *[]ClusterNetworkPolicyPort `json:"ports,omitempty"`
 }
 

--- a/config/crd/experimental/policy.networking.k8s.io_clusternetworkpolicies.yaml
+++ b/config/crd/experimental/policy.networking.k8s.io_clusternetworkpolicies.yaml
@@ -173,7 +173,7 @@ spec:
                             - message: Start port must be less than End port
                               rule: self.start < self.end
                         type: object
-                      maxItems: 100
+                      maxItems: 25
                       minItems: 1
                       type: array
                     to:
@@ -473,7 +473,7 @@ spec:
                             - podSelector
                             type: object
                         type: object
-                      maxItems: 100
+                      maxItems: 25
                       minItems: 1
                       type: array
                   required:
@@ -486,7 +486,7 @@ spec:
                     rule: '!(self.to.exists(peer, has(peer.networks) || has(peer.nodes)
                       || has(peer.domainNames)) && has(self.ports) && self.ports.exists(port,
                       has(port.namedPort)))'
-                maxItems: 100
+                maxItems: 25
                 type: array
               ingress:
                 description: |-
@@ -708,7 +708,7 @@ spec:
                             - podSelector
                             type: object
                         type: object
-                      maxItems: 100
+                      maxItems: 25
                       minItems: 1
                       type: array
                     name:
@@ -796,14 +796,14 @@ spec:
                             - message: Start port must be less than End port
                               rule: self.start < self.end
                         type: object
-                      maxItems: 100
+                      maxItems: 25
                       minItems: 1
                       type: array
                   required:
                   - action
                   - from
                   type: object
-                maxItems: 100
+                maxItems: 25
                 type: array
               priority:
                 description: |-

--- a/config/crd/standard/policy.networking.k8s.io_clusternetworkpolicies.yaml
+++ b/config/crd/standard/policy.networking.k8s.io_clusternetworkpolicies.yaml
@@ -165,7 +165,7 @@ spec:
                             - message: Start port must be less than End port
                               rule: self.start < self.end
                         type: object
-                      maxItems: 100
+                      maxItems: 25
                       minItems: 1
                       type: array
                     to:
@@ -373,14 +373,14 @@ spec:
                             - podSelector
                             type: object
                         type: object
-                      maxItems: 100
+                      maxItems: 25
                       minItems: 1
                       type: array
                   required:
                   - action
                   - to
                   type: object
-                maxItems: 100
+                maxItems: 25
                 type: array
               ingress:
                 description: |-
@@ -602,7 +602,7 @@ spec:
                             - podSelector
                             type: object
                         type: object
-                      maxItems: 100
+                      maxItems: 25
                       minItems: 1
                       type: array
                     name:
@@ -682,14 +682,14 @@ spec:
                             - message: Start port must be less than End port
                               rule: self.start < self.end
                         type: object
-                      maxItems: 100
+                      maxItems: 25
                       minItems: 1
                       type: array
                   required:
                   - action
                   - from
                   type: object
-                maxItems: 100
+                maxItems: 25
                 type: array
               priority:
                 description: |-


### PR DESCRIPTION
* It is always backwards compatible to raise limits.
* We are seeing large MaxItems to run into CEL validation cost isues.
* 25 seems to be closer to user limits than 100.

Reference

*  https://docs.google.com/document/d/1AtWQy2fNa4qXRag9cCp5_HsefD7bxKe3ea2RPn8jnSs/edit?tab=t.0#bookmark=id.ntlwhix4zktq