### PR TITLE
[conformance] Make host network ports configurable.

### DIFF
--- a/conformance/base/admin_tier/experimental-egress-selector-rules.yaml
+++ b/conformance/base/admin_tier/experimental-egress-selector-rules.yaml
@@ -14,7 +14,7 @@ spec:
         matchLabels:
           conformance-house: gryffindor
   egress:
-  - name: "allow-egress-to-36363-on-nodes"
+  - name: "allow-egress-to-{{ index .HostNetworkPorts 0 }}-on-nodes"
     action: "Accept"
     to:
     - nodes:
@@ -23,8 +23,8 @@ spec:
     ports:
       - portNumber:
           protocol: TCP
-          port: 36363
-  - name: "pass-egress-to-5353-on-nodes"
+          port: {{ index .HostNetworkPorts 0 }}
+  - name: "pass-egress-to-{{ index .HostNetworkPorts 2 }}-on-nodes"
     action: "Pass"
     to:
     - nodes:
@@ -33,7 +33,7 @@ spec:
     ports:
       - portNumber:
           protocol: UDP
-          port: 34345
+          port: {{ index .HostNetworkPorts 2 }}
   - name: "deny-egress-to-slytherin-and-nodes-and-internet"
     action: "Deny"
     to:

--- a/conformance/base/baseline_tier/experimental-egress-selector-rules.yaml
+++ b/conformance/base/baseline_tier/experimental-egress-selector-rules.yaml
@@ -10,7 +10,7 @@ spec:
       matchLabels:
         kubernetes.io/metadata.name: network-policy-conformance-gryffindor
   egress:
-  - name: "allow-egress-to-36363-on-nodes"
+  - name: "allow-egress-to-{{ index .HostNetworkPorts 0 }}-on-nodes"
     action: "Accept"
     to:
     - nodes:
@@ -19,8 +19,8 @@ spec:
     ports:
       - portRange:
           protocol: TCP
-          start: 36363
-          end: 36364
+          start: {{ index .HostNetworkPorts 0 }}
+          end: {{ index .HostNetworkPorts 1 }}
   - name: "deny-egress-to-nodes-and-internet"
     action: "Deny"
     to:

--- a/conformance/base/manifests.yaml
+++ b/conformance/base/manifests.yaml
@@ -261,55 +261,55 @@ spec:
       containers:
         - name: centaur-client
           image: registry.k8s.io/e2e-test-images/agnhost:2.45
-        - name: centaur-36363-tcp
+        - name: centaur-{{ index .HostNetworkPorts 0 }}-tcp
           image: registry.k8s.io/e2e-test-images/agnhost:2.45
-          command: ["/bin/bash", "-c", "/agnhost serve-hostname --tcp --http=false --port 36363"]
+          command: ["/bin/bash", "-c", "/agnhost serve-hostname --tcp --http=false --port {{ index .HostNetworkPorts 0 }}"]
           ports:
-            - containerPort: 36363
+            - containerPort: {{ index .HostNetworkPorts 0 }}
               protocol: TCP
-              name: web-36363
-        - name: centaur-36364-tcp
+              name: web-{{ index .HostNetworkPorts 0 }}
+        - name: centaur-{{ index .HostNetworkPorts 1 }}-tcp
           image: registry.k8s.io/e2e-test-images/agnhost:2.45
-          command: ["/bin/bash", "-c", "/agnhost serve-hostname --tcp --http=false --port 36364"]
+          command: ["/bin/bash", "-c", "/agnhost serve-hostname --tcp --http=false --port {{ index .HostNetworkPorts 1 }}"]
           ports:
-            - containerPort: 36364
+            - containerPort: {{ index .HostNetworkPorts 1 }}
               protocol: TCP
-              name: web-36364
-        - name: centaur-34345-udp
+              name: web-{{ index .HostNetworkPorts 1 }}
+        - name: centaur-{{ index .HostNetworkPorts 2 }}-udp
           image: registry.k8s.io/e2e-test-images/agnhost:2.45
           # using random http port to avoid conflict with processes on the host (there is no way to disable http port on netexec)
-          command: ["/bin/bash", "-c", "/agnhost netexec --http-port 34358 --udp-port 34345 --udp-listen-addresses $(HOST_IP)"]
+          command: ["/bin/bash", "-c", "/agnhost netexec --http-port {{ index .HostNetworkPorts 3 }} --udp-port {{ index .HostNetworkPorts 2 }} --udp-listen-addresses $(HOST_IP)"]
           ports:
-            - containerPort: 34345
+            - containerPort: {{ index .HostNetworkPorts 2 }}
               protocol: UDP
-              name: dns-34345
+              name: dns-{{ index .HostNetworkPorts 2 }}
           env:
           - name: HOST_IP
             valueFrom:
               fieldRef:
                 fieldPath: status.hostIP
-        - name: centaur-34346-udp
+        - name: centaur-{{ index .HostNetworkPorts 4 }}-udp
           image: registry.k8s.io/e2e-test-images/agnhost:2.45
           # using random http port to avoid conflict with processes on the host (there is no way to disable http port on netexec)
-          command: ["/bin/bash", "-c", "/agnhost netexec --http-port 34357 --udp-port 34346 --udp-listen-addresses $(HOST_IP)"]
+          command: ["/bin/bash", "-c", "/agnhost netexec --http-port {{ index .HostNetworkPorts 5 }} --udp-port {{ index .HostNetworkPorts 4 }} --udp-listen-addresses $(HOST_IP)"]
           ports:
-            - containerPort: 34346
+            - containerPort: {{ index .HostNetworkPorts 4 }}
               protocol: UDP
-              name: dns-34346
+              name: dns-{{ index .HostNetworkPorts 4 }}
           env:
           - name: HOST_IP
             valueFrom:
               fieldRef:
                 fieldPath: status.hostIP
-        - name: centaur-9003
+        - name: centaur-{{ index .HostNetworkPorts 6 }}
           image: registry.k8s.io/e2e-test-images/agnhost:2.45
           command: ["/bin/bash", "-c", "/agnhost porter"]
           env:
-          - name: SERVE_SCTP_PORT_9003
+          - name: SERVE_SCTP_PORT_{{ index .HostNetworkPorts 6 }}
             value: "foo"
-        - name: centaur-9005
+        - name: centaur-{{ index .HostNetworkPorts 7 }}
           image: registry.k8s.io/e2e-test-images/agnhost:2.45
           command: ["/bin/bash", "-c", "/agnhost porter"]
           env:
-          - name: SERVE_SCTP_PORT_9005
+          - name: SERVE_SCTP_PORT_{{ index .HostNetworkPorts 7 }}
             value: "foo"

--- a/conformance/tests/admin-network-policy-experimental-egress-rules.go
+++ b/conformance/tests/admin-network-policy-experimental-egress-rules.go
@@ -111,32 +111,32 @@ var CNPAdminTierEgressNodePeers = suite.ConformanceTest{
 		}, serverPod)
 		require.NoErrorf(t, err, "unable to fetch the server pod")
 		t.Run("Should support an 'allow-egress' rule policy for egress-node-peer", func(t *testing.T) {
-			// harry-potter-0 is our client pod in gryffindor namespace
-			// ensure egress is ALLOWED to forbidden-forrest from gryffindor at the 36363 TCP port
+			// harry-potter-1 is our client pod in gryffindor namespace
+			// ensure egress is ALLOWED to forbidden-forrest from gryffindor at the s.HostNetworkPorts[0] TCP port
 			// egressRule at index0 should take effect
-			success := kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-0", "tcp",
-				serverPod.Status.PodIP, int32(36363), s.TimeoutConfig.RequestTimeout, true)
+			success := kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "tcp",
+				serverPod.Status.PodIP, int32(s.HostNetworkPorts[0]), s.TimeoutConfig.RequestTimeout, true)
 			assert.True(t, success)
 		})
 		t.Run("Should support a 'pass-egress' rule policy for egress-node-peer", func(t *testing.T) {
-			// harry-potter-0 is our client pod in gryffindor namespace
-			// ensure egress is PASSED to forbidden-forrest from gryffindor at the 34345 UDP port
+			// harry-potter-1 is our client pod in gryffindor namespace
+			// ensure egress is PASSED to forbidden-forrest from gryffindor at the s.HostNetworkPorts[2] UDP port
 			// egressRule at index1 should take effect
 			success := kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "udp",
-				serverPod.Status.PodIP, int32(34345), s.TimeoutConfig.RequestTimeout, true) // Pass rule at index2 takes effect
+				serverPod.Status.PodIP, int32(s.HostNetworkPorts[2]), s.TimeoutConfig.RequestTimeout, true) // Pass rule at index2 takes effect
 			assert.True(t, success)
 		})
 		t.Run("Should support a 'deny-egress' rule policy for egress-node-peer", func(t *testing.T) {
 			// harry-potter-1 is our client pod in gryffindor namespace
 			// ensure egress is DENIED to rest of the nodes from gryffindor; egressRule at index2 should take effect
 			success := kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "tcp",
-				serverPod.Status.PodIP, int32(36364), s.TimeoutConfig.RequestTimeout, false)
+				serverPod.Status.PodIP, int32(s.HostNetworkPorts[1]), s.TimeoutConfig.RequestTimeout, false)
 			assert.True(t, success)
 			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "udp",
-				serverPod.Status.PodIP, int32(34346), s.TimeoutConfig.RequestTimeout, false)
+				serverPod.Status.PodIP, int32(s.HostNetworkPorts[4]), s.TimeoutConfig.RequestTimeout, false)
 			assert.True(t, success)
 			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "sctp",
-				serverPod.Status.PodIP, int32(9003), s.TimeoutConfig.RequestTimeout, false)
+				serverPod.Status.PodIP, int32(s.HostNetworkPorts[6]), s.TimeoutConfig.RequestTimeout, false)
 			assert.True(t, success)
 		})
 	},

--- a/conformance/tests/baseline-admin-network-policy-experimental-egress-rules.go
+++ b/conformance/tests/baseline-admin-network-policy-experimental-egress-rules.go
@@ -111,23 +111,23 @@ var CNPBaselineTierEgressNodePeers = suite.ConformanceTest{
 		require.NoErrorf(t, err, "unable to fetch the server pod")
 		t.Run("Should support an 'allow-egress' rule policy for egress-node-peer", func(t *testing.T) {
 			// harry-potter-0 is our client pod in gryffindor namespace
-			// ensure egress is ALLOWED to forbidden-forrest from gryffindor at the 36363 TCP port
+			// ensure egress is ALLOWED to forbidden-forrest from gryffindor at the s.HostNetworkPorts[0] TCP port
 			// egressRule at index0 should take effect
 			success := kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-0", "tcp",
-				serverPod.Status.PodIP, int32(36363), s.TimeoutConfig.RequestTimeout, true)
+				serverPod.Status.PodIP, int32(s.HostNetworkPorts[0]), s.TimeoutConfig.RequestTimeout, true)
 			assert.True(t, success)
 			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "tcp",
-				serverPod.Status.PodIP, int32(36364), s.TimeoutConfig.RequestTimeout, true) // Pass rule at index2 takes effect
+				serverPod.Status.PodIP, int32(s.HostNetworkPorts[1]), s.TimeoutConfig.RequestTimeout, true) // Pass rule at index2 takes effect
 			assert.True(t, success)
 		})
 		t.Run("Should support a 'deny-egress' rule policy for egress-node-peer", func(t *testing.T) {
 			// harry-potter-1 is our client pod in gryffindor namespace
 			// ensure egress is DENIED to rest of the nodes from gryffindor; egressRule at index1 should take effect
 			success := kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "udp",
-				serverPod.Status.PodIP, int32(34346), s.TimeoutConfig.RequestTimeout, false)
+				serverPod.Status.PodIP, int32(s.HostNetworkPorts[4]), s.TimeoutConfig.RequestTimeout, false)
 			assert.True(t, success)
 			success = kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "sctp",
-				serverPod.Status.PodIP, int32(9003), s.TimeoutConfig.RequestTimeout, false)
+				serverPod.Status.PodIP, int32(s.HostNetworkPorts[6]), s.TimeoutConfig.RequestTimeout, false)
 			assert.True(t, success)
 		})
 	},


### PR DESCRIPTION
Add HostNetworkPortRangeStart and HostNetworkPortRangeEnd to
the config to let users specify host port range.
Update Apply logic to execute template with the dynamic values.

Inspired by gateway-api (as always :) ) https://github.com/kubernetes-sigs/gateway-api/blob/9948587970dffd2d9734f0c09da17e524a57a17d/conformance/utils/kubernetes/apply.go#L91-L109

I may need to backport this, because current tests are very flaky d/s

Fixes [#341](https://github.com/kubernetes-sigs/network-policy-api/issues/341)