### PR TITLE
chore(docs): add cnp support in kube-ovn

### DIFF
--- a/site-src/implementations.md
+++ b/site-src/implementations.md
@@ -8,9 +8,10 @@ implementations, the versions they cover, and documentation to help users get st
 
 ## ClusterNetworkPolicy
 
-Updated: 13-Oct-2025
+Updated: 24-Jan-2026
 
 - [Kube-network-policies](https://github.com/kubernetes-sigs/kube-network-policies)
+- [Kube-OVN CNI](https://github.com/kubeovn/kube-ovn) (Experimental support)
 
 ## AdminNetworkPolicy and BaseLineAdminNetworkPolicy (v1alpha1)
 
@@ -19,6 +20,6 @@ Updated: 14-Nov-2024
 - [Kube-network-policies](https://github.com/kubernetes-sigs/kube-network-policies/tree/v0.8.1)
 - [OVN-Kubernetes CNI](https://github.com/ovn-org/ovn-kubernetes/) (Has implemented standard fields of the API + Nodes/Networks in Experimental)
 - [Antrea CNI](https://github.com/antrea-io/antrea/) (Has implemented standard fields of the API)
-- [KubeOVN CNI](https://github.com/kubeovn/kube-ovn) (Has implemented standard fields of the API)
+- [Kube-OVN CNI](https://github.com/kubeovn/kube-ovn) (Has implemented standard fields of the API)
 - [Calico CNI](https://github.com/projectcalico/calico/issues/7578) (Has implemented standard fields of the API for Admin Network Policy + Networks peer in experimental, Baseline Admin network policy support in progress)
 - [Cilium CNI](https://github.com/cilium/cilium/issues/23380) (tracking issue)


### PR DESCRIPTION
CNP support was introduced as an experimental/undocumented feature in Kube-OVN in version v1.15.0
