### PR TITLE
Fix typo 'continguous'.

### DIFF
--- a/apis/v1alpha2/clusternetworkpolicy_types.go
+++ b/apis/v1alpha2/clusternetworkpolicy_types.go
@@ -496,7 +496,7 @@ type Port struct {
 	// +kubebuilder:validation:Maximum=65535
 	Number int32 `json:"number,omitempty"`
 
-	// Range defines a continguous range of ports.
+	// Range defines a contiguous range of ports.
 	//
 	// +optional
 	Range *PortRange `json:"range,omitempty"`

--- a/config/crd/experimental/policy.networking.k8s.io_clusternetworkpolicies.yaml
+++ b/config/crd/experimental/policy.networking.k8s.io_clusternetworkpolicies.yaml
@@ -136,7 +136,7 @@ spec:
                                     minimum: 1
                                     type: integer
                                   range:
-                                    description: Range defines a continguous range
+                                    description: Range defines a contiguous range
                                       of ports.
                                     properties:
                                       end:
@@ -180,7 +180,7 @@ spec:
                                     minimum: 1
                                     type: integer
                                   range:
-                                    description: Range defines a continguous range
+                                    description: Range defines a contiguous range
                                       of ports.
                                     properties:
                                       end:
@@ -224,7 +224,7 @@ spec:
                                     minimum: 1
                                     type: integer
                                   range:
-                                    description: Range defines a continguous range
+                                    description: Range defines a contiguous range
                                       of ports.
                                     properties:
                                       end:
@@ -834,7 +834,7 @@ spec:
                                     minimum: 1
                                     type: integer
                                   range:
-                                    description: Range defines a continguous range
+                                    description: Range defines a contiguous range
                                       of ports.
                                     properties:
                                       end:
@@ -878,7 +878,7 @@ spec:
                                     minimum: 1
                                     type: integer
                                   range:
-                                    description: Range defines a continguous range
+                                    description: Range defines a contiguous range
                                       of ports.
                                     properties:
                                       end:
@@ -922,7 +922,7 @@ spec:
                                     minimum: 1
                                     type: integer
                                   range:
-                                    description: Range defines a continguous range
+                                    description: Range defines a contiguous range
                                       of ports.
                                     properties:
                                       end:

--- a/config/crd/standard/policy.networking.k8s.io_clusternetworkpolicies.yaml
+++ b/config/crd/standard/policy.networking.k8s.io_clusternetworkpolicies.yaml
@@ -136,7 +136,7 @@ spec:
                                     minimum: 1
                                     type: integer
                                   range:
-                                    description: Range defines a continguous range
+                                    description: Range defines a contiguous range
                                       of ports.
                                     properties:
                                       end:
@@ -180,7 +180,7 @@ spec:
                                     minimum: 1
                                     type: integer
                                   range:
-                                    description: Range defines a continguous range
+                                    description: Range defines a contiguous range
                                       of ports.
                                     properties:
                                       end:
@@ -224,7 +224,7 @@ spec:
                                     minimum: 1
                                     type: integer
                                   range:
-                                    description: Range defines a continguous range
+                                    description: Range defines a contiguous range
                                       of ports.
                                     properties:
                                       end:
@@ -736,7 +736,7 @@ spec:
                                     minimum: 1
                                     type: integer
                                   range:
-                                    description: Range defines a continguous range
+                                    description: Range defines a contiguous range
                                       of ports.
                                     properties:
                                       end:
@@ -780,7 +780,7 @@ spec:
                                     minimum: 1
                                     type: integer
                                   range:
-                                    description: Range defines a continguous range
+                                    description: Range defines a contiguous range
                                       of ports.
                                     properties:
                                       end:
@@ -824,7 +824,7 @@ spec:
                                     minimum: 1
                                     type: integer
                                   range:
-                                    description: Range defines a continguous range
+                                    description: Range defines a contiguous range
                                       of ports.
                                     properties:
                                       end:


### PR DESCRIPTION
Spotted a typo in the PortRange description.