### PR TITLE
Update conformance test for new protocol/port schema

### DIFF
--- a/conformance/base/admin_tier/experimental-egress-selector-rules.yaml
+++ b/conformance/base/admin_tier/experimental-egress-selector-rules.yaml
@@ -20,20 +20,20 @@ spec:
     - nodes:
         matchLabels:
           kubernetes.io/os: linux
-    ports:
-      - portNumber:
-          protocol: TCP
-          port: {{ index .HostNetworkPorts 0 }}
+    protocols:
+      - tcp:
+          destinationPort:
+            number: {{ index .HostNetworkPorts 0 }}
   - name: "pass-egress-to-{{ index .HostNetworkPorts 2 }}-on-nodes"
     action: "Pass"
     to:
     - nodes:
         matchLabels:
           kubernetes.io/os: linux
-    ports:
-      - portNumber:
-          protocol: UDP
-          port: {{ index .HostNetworkPorts 2 }}
+    protocols:
+      - udp:
+          destinationPort:
+            number: {{ index .HostNetworkPorts 2 }}
   - name: "deny-egress-to-slytherin-and-nodes-and-internet"
     action: "Deny"
     to:

--- a/conformance/base/admin_tier/standard-egress-sctp-rules.yaml
+++ b/conformance/base/admin_tier/standard-egress-sctp-rules.yaml
@@ -34,30 +34,30 @@ spec:
     - namespaces:
         matchLabels:
           kubernetes.io/metadata.name: network-policy-conformance-slytherin
-    ports:
-      - portNumber:
-          protocol: SCTP
-          port: 9003
+    protocols:
+      - sctp:
+          destinationPort:
+            number: 9003
   - name: "pass-to-slytherin-at-port-9003"
     action: "Pass"
     to:
     - namespaces:
         matchLabels:
           kubernetes.io/metadata.name: network-policy-conformance-slytherin
-    ports:
-      - portNumber:
-          protocol: SCTP
-          port: 9003
+    protocols:
+      - sctp:
+          destinationPort:
+            number: 9003
   - name: "allow-to-hufflepuff-at-port-9003"
     action: "Accept"
     to:
     - namespaces:
         matchLabels:
           kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
-    ports:
-      - portNumber:
-          protocol: SCTP
-          port: 9003
+    protocols:
+      - sctp:
+          destinationPort:
+            number: 9003
   - name: "deny-to-hufflepuff-everything-else"
     action: "Deny"
     to:

--- a/conformance/base/admin_tier/standard-egress-tcp-rules.yaml
+++ b/conformance/base/admin_tier/standard-egress-tcp-rules.yaml
@@ -34,30 +34,30 @@ spec:
     - namespaces:
         matchLabels:
           kubernetes.io/metadata.name: network-policy-conformance-slytherin
-    ports:
-      - portNumber:
-          protocol: TCP
-          port: 80
+    protocols:
+      - tcp:
+          destinationPort:
+            number: 80
   - name: "pass-to-slytherin-at-port-80"
     action: "Pass"
     to:
     - namespaces:
         matchLabels:
           kubernetes.io/metadata.name: network-policy-conformance-slytherin
-    ports:
-      - portNumber:
-          protocol: TCP
-          port: 80
+    protocols:
+      - tcp:
+          destinationPort:
+            number: 80
   - name: "allow-to-hufflepuff-at-port-8080"
     action: "Accept"
     to:
     - namespaces:
         matchLabels:
           kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
-    ports:
-      - portNumber:
-          protocol: TCP
-          port: 8080
+    protocols:
+      - tcp:
+          destinationPort:
+            number: 8080
   - name: "deny-to-hufflepuff-everything-else"
     action: "Deny"
     to:

--- a/conformance/base/admin_tier/standard-egress-udp-rules.yaml
+++ b/conformance/base/admin_tier/standard-egress-udp-rules.yaml
@@ -34,30 +34,30 @@ spec:
     - namespaces:
         matchLabels:
           kubernetes.io/metadata.name: network-policy-conformance-slytherin
-    ports:
-      - portNumber:
-          protocol: UDP
-          port: 5353
+    protocols:
+      - udp:
+          destinationPort:
+            number: 5353
   - name: "pass-to-slytherin-at-port-5353"
     action: "Pass"
     to:
     - namespaces:
         matchLabels:
           kubernetes.io/metadata.name: network-policy-conformance-slytherin
-    ports:
-      - portNumber:
-          protocol: UDP
-          port: 5353
+    protocols:
+      - udp:
+          destinationPort:
+            number: 5353
   - name: "allow-to-gryffindor-at-port-53"
     action: "Accept"
     to:
     - namespaces:
         matchLabels:
           kubernetes.io/metadata.name: network-policy-conformance-gryffindor
-    ports:
-      - portNumber:
-          protocol: UDP
-          port: 53
+    protocols:
+      - udp:
+          destinationPort:
+            number: 53
   - name: "deny-to-gryffindor-everything-else"
     action: "Deny"
     to:

--- a/conformance/base/admin_tier/standard-gress-rules-combined.yaml
+++ b/conformance/base/admin_tier/standard-gress-rules-combined.yaml
@@ -34,48 +34,48 @@ spec:
     - namespaces:
         matchLabels:
           kubernetes.io/metadata.name: network-policy-conformance-slytherin
-    ports:
-      - portNumber:
-          protocol: TCP
-          port: 80
-      - portNumber:
-          protocol: UDP
-          port: 53
-      - portNumber:
-          protocol: SCTP
-          port: 9003
+    protocols:
+      - tcp:
+          destinationPort:
+            number: 80
+      - udp:
+          destinationPort:
+            number: 53
+      - sctp:
+          destinationPort:
+            number: 9003
   - name: "pass-to-slytherin-at-port-80-53-9003"
     action: "Pass"
     to:
     - namespaces:
         matchLabels:
           kubernetes.io/metadata.name: network-policy-conformance-slytherin
-    ports:
-      - portNumber:
-          protocol: TCP
-          port: 80
-      - portNumber:
-          protocol: UDP
-          port: 53
-      - portNumber:
-          protocol: SCTP
-          port: 9003
+    protocols:
+      - tcp:
+          destinationPort:
+            number: 80
+      - udp:
+          destinationPort:
+            number: 53
+      - sctp:
+          destinationPort:
+            number: 9003
   - name: "allow-to-hufflepuff-at-ports-8080-5353-9003"
     action: "Accept"
     to:
     - namespaces:
         matchLabels:
           kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
-    ports:
-      - portNumber:
-          protocol: TCP
-          port: 8080
-      - portNumber:
-          protocol: UDP
-          port: 5353
-      - portNumber:
-          protocol: SCTP
-          port: 9003
+    protocols:
+      - tcp:
+          destinationPort:
+            number: 8080
+      - udp:
+          destinationPort:
+            number: 5353
+      - sctp:
+          destinationPort:
+            number: 9003
   - name: "deny-to-hufflepuff-everything-else"
     action: "Deny"
     to:
@@ -107,48 +107,48 @@ spec:
     - namespaces:
         matchLabels:
           kubernetes.io/metadata.name: network-policy-conformance-slytherin
-    ports:
-      - portNumber:
-          protocol: TCP
-          port: 80
-      - portNumber:
-          protocol: UDP
-          port: 53
-      - portNumber:
-          protocol: SCTP
-          port: 9003
+    protocols:
+      - tcp:
+          destinationPort:
+            number: 80
+      - udp:
+          destinationPort:
+            number: 53
+      - sctp:
+          destinationPort:
+            number: 9003
   - name: "pass-from-slytherin-at-port-80-53-9003"
     action: "Pass"
     from:
     - namespaces:
         matchLabels:
           kubernetes.io/metadata.name: network-policy-conformance-slytherin
-    ports:
-      - portNumber:
-          protocol: TCP
-          port: 80
-      - portNumber:
-          protocol: UDP
-          port: 53
-      - portNumber:
-          protocol: SCTP
-          port: 9003
+    protocols:
+      - tcp:
+          destinationPort:
+            number: 80
+      - udp:
+          destinationPort:
+            number: 53
+      - sctp:
+          destinationPort:
+            number: 9003
   - name: "allow-from-hufflepuff-at-port-80-5353-9003"
     action: "Accept"
     from:
     - namespaces:
         matchLabels:
           kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
-    ports:
-      - portNumber:
-          protocol: TCP
-          port: 80
-      - portNumber:
-          protocol: UDP
-          port: 5353
-      - portNumber:
-          protocol: SCTP
-          port: 9003
+    protocols:
+      - tcp:
+          destinationPort:
+            number: 80
+      - udp:
+          destinationPort:
+            number: 5353
+      - sctp:
+          destinationPort:
+            number: 9003
   - name: "deny-from-hufflepuff-everything-else"
     action: "Deny"
     from:

--- a/conformance/base/admin_tier/standard-ingress-sctp-rules.yaml
+++ b/conformance/base/admin_tier/standard-ingress-sctp-rules.yaml
@@ -34,30 +34,30 @@ spec:
     - namespaces:
         matchLabels:
           kubernetes.io/metadata.name: network-policy-conformance-slytherin
-    ports:
-      - portNumber:
-          protocol: SCTP
-          port: 9003
+    protocols:
+      - sctp:
+          destinationPort:
+            number: 9003
   - name: "pass-from-slytherin-at-port-9003"
     action: "Pass"
     from:
     - namespaces:
         matchLabels:
           kubernetes.io/metadata.name: network-policy-conformance-slytherin
-    ports:
-      - portNumber:
-          protocol: SCTP
-          port: 9003
+    protocols:
+      - sctp:
+          destinationPort:
+            number: 9003
   - name: "allow-from-hufflepuff-at-port-9003"
     action: "Accept"
     from:
     - namespaces:
         matchLabels:
           kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
-    ports:
-      - portNumber:
-          protocol: SCTP
-          port: 9003
+    protocols:
+      - sctp:
+          destinationPort:
+            number: 9003
   - name: "deny-from-hufflepuff-everything-else"
     action: "Deny"
     from:

--- a/conformance/base/admin_tier/standard-ingress-tcp-rules.yaml
+++ b/conformance/base/admin_tier/standard-ingress-tcp-rules.yaml
@@ -34,30 +34,30 @@ spec:
     - namespaces:
         matchLabels:
           kubernetes.io/metadata.name: network-policy-conformance-slytherin
-    ports:
-      - portNumber:
-          protocol: TCP
-          port: 80
+    protocols:
+      - tcp:
+          destinationPort:
+            number: 80
   - name: "pass-from-slytherin-at-port-80"
     action: "Pass"
     from:
     - namespaces:
         matchLabels:
           kubernetes.io/metadata.name: network-policy-conformance-slytherin
-    ports:
-      - portNumber:
-          protocol: TCP
-          port: 80
+    protocols:
+      - tcp:
+          destinationPort:
+            number: 80
   - name: "allow-from-hufflepuff-at-port-80"
     action: "Accept"
     from:
     - namespaces:
         matchLabels:
           kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
-    ports:
-      - portNumber:
-          protocol: TCP
-          port: 80
+    protocols:
+      - tcp:
+          destinationPort:
+            number: 80
   - name: "deny-from-hufflepuff-everything-else"
     action: "Deny"
     from:

--- a/conformance/base/admin_tier/standard-ingress-udp-rules.yaml
+++ b/conformance/base/admin_tier/standard-ingress-udp-rules.yaml
@@ -34,30 +34,30 @@ spec:
     - namespaces:
         matchLabels:
           kubernetes.io/metadata.name: network-policy-conformance-slytherin
-    ports:
-      - portNumber:
-          protocol: UDP
-          port: 5353
+    protocols:
+      - udp:
+          destinationPort:
+            number: 5353
   - name: "pass-from-slytherin-at-port-5353"
     action: "Pass"
     from:
     - namespaces:
         matchLabels:
           kubernetes.io/metadata.name: network-policy-conformance-slytherin
-    ports:
-      - portNumber:
-          protocol: UDP
-          port: 5353
+    protocols:
+      - udp:
+          destinationPort:
+            number: 5353
   - name: "allow-from-gryffindor-at-port-53"
     action: "Accept"
     from:
     - namespaces:
         matchLabels:
           kubernetes.io/metadata.name: network-policy-conformance-gryffindor
-    ports:
-      - portNumber:
-          protocol: UDP
-          port: 53
+    protocols:
+      - udp:
+          destinationPort:
+            number: 53
   - name: "deny-from-gryffindor-everything-else"
     action: "Deny"
     from:

--- a/conformance/base/baseline_tier/experimental-egress-selector-rules.yaml
+++ b/conformance/base/baseline_tier/experimental-egress-selector-rules.yaml
@@ -16,11 +16,12 @@ spec:
     - nodes:
         matchLabels:
           kubernetes.io/os: linux
-    ports:
-      - portRange:
-          protocol: TCP
-          start: {{ index .HostNetworkPorts 0 }}
-          end: {{ index .HostNetworkPorts 1 }}
+    protocols:
+      - tcp:
+          destinationPort:
+            range:
+              start: {{ index .HostNetworkPorts 0 }}
+              end: {{ index .HostNetworkPorts 1 }}
   - name: "deny-egress-to-nodes-and-internet"
     action: "Deny"
     to:

--- a/conformance/base/baseline_tier/standard-egress-sctp-rules.yaml
+++ b/conformance/base/baseline_tier/standard-egress-sctp-rules.yaml
@@ -28,20 +28,20 @@ spec:
     - namespaces:
         matchLabels:
           kubernetes.io/metadata.name: network-policy-conformance-slytherin
-    ports:
-      - portNumber:
-          protocol: SCTP
-          port: 9003
+    protocols:
+      - sctp:
+          destinationPort:
+            number: 9003
   - name: "allow-to-hufflepuff-at-port-9003"
     action: "Accept"
     to:
     - namespaces:
         matchLabels:
           kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
-    ports:
-      - portNumber:
-          protocol: SCTP
-          port: 9003
+    protocols:
+      - sctp:
+          destinationPort:
+            number: 9003
   - name: "deny-to-hufflepuff-everything-else"
     action: "Deny"
     to:

--- a/conformance/base/baseline_tier/standard-egress-tcp-rules.yaml
+++ b/conformance/base/baseline_tier/standard-egress-tcp-rules.yaml
@@ -28,20 +28,20 @@ spec:
     - namespaces:
         matchLabels:
           kubernetes.io/metadata.name: network-policy-conformance-slytherin
-    ports:
-      - portNumber:
-          protocol: TCP
-          port: 80
+    protocols:
+      - tcp:
+          destinationPort:
+            number: 80
   - name: "allow-to-hufflepuff-at-port-8080"
     action: "Accept"
     to:
     - namespaces:
         matchLabels:
           kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
-    ports:
-      - portNumber:
-          protocol: TCP
-          port: 8080
+    protocols:
+      - tcp:
+          destinationPort:
+            number: 8080
   - name: "deny-to-hufflepuff-everything-else"
     action: "Deny"
     to:

--- a/conformance/base/baseline_tier/standard-egress-udp-rules.yaml
+++ b/conformance/base/baseline_tier/standard-egress-udp-rules.yaml
@@ -28,20 +28,20 @@ spec:
     - namespaces:
         matchLabels:
           kubernetes.io/metadata.name: network-policy-conformance-slytherin
-    ports:
-      - portNumber:
-          protocol: UDP
-          port: 5353
+    protocols:
+      - udp:
+          destinationPort:
+            number: 5353
   - name: "allow-to-gryffindor-at-port-53"
     action: "Accept"
     to:
     - namespaces:
         matchLabels:
           kubernetes.io/metadata.name: network-policy-conformance-gryffindor
-    ports:
-      - portNumber:
-          protocol: UDP
-          port: 53
+    protocols:
+      - udp:
+          destinationPort:
+            number: 53
   - name: "deny-to-gryffindor-everything-else"
     action: "Deny"
     to:

--- a/conformance/base/baseline_tier/standard-gress-rules-combined.yaml
+++ b/conformance/base/baseline_tier/standard-gress-rules-combined.yaml
@@ -28,32 +28,32 @@ spec:
     - namespaces:
         matchLabels:
           kubernetes.io/metadata.name: network-policy-conformance-slytherin
-    ports:
-      - portNumber:
-          protocol: TCP
-          port: 80
-      - portNumber:
-          protocol: UDP
-          port: 53
-      - portNumber:
-          protocol: SCTP
-          port: 9003
+    protocols:
+      - tcp:
+          destinationPort:
+            number: 80
+      - udp:
+          destinationPort:
+            number: 53
+      - sctp:
+          destinationPort:
+            number: 9003
   - name: "allow-to-hufflepuff-at-ports-8080-5353"
     action: "Accept"
     to:
     - namespaces:
         matchLabels:
           kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
-    ports:
-      - portNumber:
-          protocol: TCP
-          port: 8080
-      - portNumber:
-          protocol: UDP
-          port: 5353
-      - portNumber:
-          protocol: SCTP
-          port: 9003
+    protocols:
+      - tcp:
+          destinationPort:
+            number: 8080
+      - udp:
+          destinationPort:
+            number: 5353
+      - sctp:
+          destinationPort:
+            number: 9003
   - name: "deny-to-hufflepuff-everything-else"
     action: "Deny"
     to:
@@ -79,32 +79,32 @@ spec:
     - namespaces:
         matchLabels:
           kubernetes.io/metadata.name: network-policy-conformance-slytherin
-    ports:
-      - portNumber:
-          protocol: TCP
-          port: 80
-      - portNumber:
-          protocol: UDP
-          port: 53
-      - portNumber:
-          protocol: SCTP
-          port: 9003
+    protocols:
+      - tcp:
+          destinationPort:
+            number: 80
+      - udp:
+          destinationPort:
+            number: 53
+      - sctp:
+          destinationPort:
+            number: 9003
   - name: "allow-from-hufflepuff-at-port-80-5353-9003"
     action: "Accept"
     from:
     - namespaces:
         matchLabels:
           kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
-    ports:
-      - portNumber:
-          protocol: TCP
-          port: 80
-      - portNumber:
-          protocol: UDP
-          port: 5353
-      - portNumber:
-          protocol: SCTP
-          port: 9003
+    protocols:
+      - tcp:
+          destinationPort:
+            number: 80
+      - udp:
+          destinationPort:
+            number: 5353
+      - sctp:
+          destinationPort:
+            number: 9003
   - name: "deny-from-hufflepuff-everything-else"
     action: "Deny"
     from:

--- a/conformance/base/baseline_tier/standard-ingress-sctp-rules.yaml
+++ b/conformance/base/baseline_tier/standard-ingress-sctp-rules.yaml
@@ -28,20 +28,20 @@ spec:
     - namespaces:
         matchLabels:
           kubernetes.io/metadata.name: network-policy-conformance-slytherin
-    ports:
-      - portNumber:
-          protocol: SCTP
-          port: 9003
+    protocols:
+      - sctp:
+          destinationPort:
+            number: 9003
   - name: "allow-from-hufflepuff-at-port-9003"
     action: "Accept"
     from:
     - namespaces:
         matchLabels:
           kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
-    ports:
-      - portNumber:
-          protocol: SCTP
-          port: 9003
+    protocols:
+      - sctp:
+          destinationPort:
+            number: 9003
   - name: "deny-from-hufflepuff-everything-else"
     action: "Deny"
     from:

--- a/conformance/base/baseline_tier/standard-ingress-tcp-rules.yaml
+++ b/conformance/base/baseline_tier/standard-ingress-tcp-rules.yaml
@@ -28,20 +28,20 @@ spec:
     - namespaces:
         matchLabels:
           kubernetes.io/metadata.name: network-policy-conformance-slytherin
-    ports:
-      - portNumber:
-          protocol: TCP
-          port: 80
+    protocols:
+      - tcp:
+          destinationPort:
+            number: 80
   - name: "allow-from-hufflepuff-at-port-80"
     action: "Accept"
     from:
     - namespaces:
         matchLabels:
           kubernetes.io/metadata.name: network-policy-conformance-hufflepuff
-    ports:
-      - portNumber:
-          protocol: TCP
-          port: 80
+    protocols:
+      - tcp:
+          destinationPort:
+            number: 80
   - name: "deny-from-hufflepuff-everything-else"
     action: "Deny"
     from:

--- a/conformance/base/baseline_tier/standard-ingress-udp-rules.yaml
+++ b/conformance/base/baseline_tier/standard-ingress-udp-rules.yaml
@@ -28,20 +28,20 @@ spec:
     - namespaces:
         matchLabels:
           kubernetes.io/metadata.name: network-policy-conformance-slytherin
-    ports:
-      - portNumber:
-          protocol: UDP
-          port: 5353
+    protocols:
+      - udp:
+          destinationPort:
+            number: 5353
   - name: "allow-from-gryffindor-at-port-53"
     action: "Accept"
     from:
     - namespaces:
         matchLabels:
           kubernetes.io/metadata.name: network-policy-conformance-gryffindor
-    ports:
-      - portNumber:
-          protocol: UDP
-          port: 53
+    protocols:
+      - udp:
+          destinationPort:
+            number: 53
   - name: "deny-from-gryffindor-everything-else"
     action: "Deny"
     from:


### PR DESCRIPTION
Update the conformance test YAML files to match the recent protocol/port changes in the v1alpha2 CRD.