### PR TITLE
[conformance] increase test timeout due to the added retries

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -114,7 +114,7 @@ jobs:
       run: |
         go mod download
         REPO_VERSION=$(git describe --always --dirty)
-        go test  -v ./conformance -run TestConformanceProfiles -args --conformance-profiles=ClusterNetworkPolicy --organization=kubernetes --project=kube-network-policies --url=https://github.com/kubernetes-sigs/kube-network-policies --version=${REPO_VERSION} --contact=https://github.com/kubernetes-sigs/kube-network-policies/issues/new --additional-info=https://github.com/kubernetes-sigs/kube-network-policies
+        go test  -v ./conformance -run TestConformanceProfiles -timeout 20m -args --conformance-profiles=ClusterNetworkPolicy --organization=kubernetes --project=kube-network-policies --url=https://github.com/kubernetes-sigs/kube-network-policies --version=${REPO_VERSION} --contact=https://github.com/kubernetes-sigs/kube-network-policies/issues/new --additional-info=https://github.com/kubernetes-sigs/kube-network-policies
 
     - name: Upload Junit Reports
       if: always()

--- a/Makefile
+++ b/Makefile
@@ -59,17 +59,17 @@ crd-e2e: ## Run the CRD e2e tests.
 .PHONY: conformance
 conformance: ## Run the conformance tests.
 	go test ${GO_TEST_FLAGS} -v ./conformance \
-		-run '^TestConformance$$' -args ${CONFORMANCE_FLAGS}
+		-run '^TestConformance$$' -timeout 20m -args ${CONFORMANCE_FLAGS}
 
 .PHONY: conformance-profiles
 conformance-profiles: ## Run the conformance profiles.
 	go test ${GO_TEST_FLAGS} -v ./conformance \
-		-run '^TestConformanceProfiles$$' -args ${CONFORMANCE_FLAGS}
+		-run '^TestConformanceProfiles$$' -timeout 20m -args ${CONFORMANCE_FLAGS}
 
 .PHONY: conformance-profiles-default
 conformance-profiles-default: ## Run the default conformance profile.
 	go test ${GO_TEST_FLAGS} -v ./conformance \
-		-run '^TestConformanceProfiles$$' -args \
+		-run '^TestConformanceProfiles$$' -timeout 20m -args \
 		--conformance-profiles=ClusterNetworkPolicy
 
 ##@ Deployment


### PR DESCRIPTION
test run takes about 16 min now after adding retries https://github.com/kubernetes-sigs/network-policy-api/pull/353
example form the release-0.1 branch since main is broken https://github.com/kubernetes-sigs/network-policy-api/actions/runs/21985251260/job/63517709072?pr=359
Now instead of timing out https://github.com/kubernetes-sigs/network-policy-api/actions/runs/21953019646/job/63408868752 it properly fails in 16 min https://github.com/kubernetes-sigs/network-policy-api/actions/runs/22060712533/job/63739971377?pr=362

You can see working version on relase-0.1 https://github.com/kubernetes-sigs/network-policy-api/pull/359