### PR TITLE
API docs: clarify ICMP related.

### DIFF
--- a/apis/v1alpha2/clusternetworkpolicy_types.go
+++ b/apis/v1alpha2/clusternetworkpolicy_types.go
@@ -188,11 +188,11 @@ type ClusterNetworkPolicyIngressRule struct {
 	Name string `json:"name,omitempty"`
 
 	// Action specifies the effect this rule will have on matching
-	// traffic. Currently the following actions are supported:
+	// traffic. Currently, the following actions are supported:
 	//
-	// - Accept: Accepts the selected traffic, allowing it into
-	//   the destination. No further ClusterNetworkPolicy or
-	//   NetworkPolicy rules will be processed.
+	// - Accept: Accepts the selected traffic, including replies to that
+	//   traffic and related ICMP traffic. No further ingress
+	//   ClusterNetworkPolicy or NetworkPolicy rules will be processed.
 	//
 	//   Note: while Accept ensures traffic is accepted by
 	//   Kubernetes network policy, it is still possible that the
@@ -245,15 +245,15 @@ type ClusterNetworkPolicyEgressRule struct {
 	Name string `json:"name,omitempty"`
 
 	// Action specifies the effect this rule will have on matching
-	// traffic.  Currently the following actions are supported:
+	// traffic. Currently, the following actions are supported:
 	//
-	// - Accept: Accepts the selected traffic, allowing it to
-	//   egress. No further ClusterNetworkPolicy or NetworkPolicy
-	//   rules will be processed.
+	// - Accept: Accepts the selected traffic, including replies to that
+	//   traffic and related ICMP traffic. No further egress
+	//   ClusterNetworkPolicy or NetworkPolicy rules will be processed
+	//   but any ingress rules at the destination do apply.
 	//
-	// - Deny: Drops the selected traffic. No further
-	//   ClusterNetworkPolicy or NetworkPolicy rules will be
-	//   processed.
+	// - Deny: Drops the selected traffic. No further ClusterNetworkPolicy or
+	//   NetworkPolicy rules will be processed.
 	//
 	// - Pass: Skips all further ClusterNetworkPolicy rules in the
 	//   current tier for the selected traffic, and passes
@@ -288,20 +288,16 @@ type ClusterNetworkPolicyEgressRule struct {
 type ClusterNetworkPolicyRuleAction string
 
 const (
-	// ClusterNetworkPolicyRuleActionAccept indicates that
-	// matching traffic will be accepted and no further policy
-	// evaluation will be done. This is a final decision.
+	// ClusterNetworkPolicyRuleActionAccept stops further rule processing of
+	// this policy direction (Ingress/Egress) and accepts the traffic.
 	ClusterNetworkPolicyRuleActionAccept ClusterNetworkPolicyRuleAction = "Accept"
-	// ClusterNetworkPolicyRuleActionDeny indicates that matching traffic
-	// will be denied and no further policy evaluation will be done.
-	// This is a final decision.
+	// ClusterNetworkPolicyRuleActionDeny stops further rule processing and
+	// drops the traffic.
 	ClusterNetworkPolicyRuleActionDeny ClusterNetworkPolicyRuleAction = "Deny"
-	// ClusterNetworkPolicyRuleActionPass indicates that matching traffic
-	// will jump to the next tier evaluation. That means that all the rules
-	// with lower precedence at the same tier will be ignored,
-	// but evaluation will continue at the next tier.
-	// For example, if an Admin tier CNP uses Pass action,
-	// NetworkPolicy evaluation will happen next.
+	// ClusterNetworkPolicyRuleActionPass skips rules with lower precedence in
+	// the current tier and continues processing in the next tier. For example,
+	// if an Admin tier CNP uses Pass action, NetworkPolicy evaluation will
+	// happen next.
 	ClusterNetworkPolicyRuleActionPass ClusterNetworkPolicyRuleAction = "Pass"
 )
 
@@ -379,6 +375,11 @@ type ClusterNetworkPolicyEgressPeer struct {
 	// well. So if you Accept or Deny traffic to `"0.0.0.0/0"`, that will allow
 	// or deny all IPv4 pod-to-pod traffic as well. If you don't want that,
 	// add a rule that Passes all pod traffic before the Networks rule.
+	//
+	// Networks matches both regular IP traffic and ICMP traffic to/from
+	// the specified CIDRs. For example, a Networks entry of "0.0.0.0/0"
+	// will match both IPv4 and ICMP traffic, while "::/0" will match
+	// both IPv6 and ICMPv6 traffic.
 	//
 	// Each item in Networks should be provided in the CIDR format and should be
 	// IPv4 or IPv6, for example "10.0.0.0/8" or "fd00::/8".

--- a/config/crd/experimental/policy.networking.k8s.io_clusternetworkpolicies.yaml
+++ b/config/crd/experimental/policy.networking.k8s.io_clusternetworkpolicies.yaml
@@ -75,15 +75,15 @@ spec:
                     action:
                       description: |-
                         Action specifies the effect this rule will have on matching
-                        traffic.  Currently the following actions are supported:
+                        traffic. Currently, the following actions are supported:
 
-                        - Accept: Accepts the selected traffic, allowing it to
-                          egress. No further ClusterNetworkPolicy or NetworkPolicy
-                          rules will be processed.
+                        - Accept: Accepts the selected traffic, including replies to that
+                          traffic and related ICMP traffic. No further egress
+                          ClusterNetworkPolicy or NetworkPolicy rules will be processed
+                          but any ingress rules at the destination do apply.
 
-                        - Deny: Drops the selected traffic. No further
-                          ClusterNetworkPolicy or NetworkPolicy rules will be
-                          processed.
+                        - Deny: Drops the selected traffic. No further ClusterNetworkPolicy or
+                          NetworkPolicy rules will be processed.
 
                         - Pass: Skips all further ClusterNetworkPolicy rules in the
                           current tier for the selected traffic, and passes
@@ -373,6 +373,11 @@ spec:
                               or deny all IPv4 pod-to-pod traffic as well. If you don't want that,
                               add a rule that Passes all pod traffic before the Networks rule.
 
+                              Networks matches both regular IP traffic and ICMP traffic to/from
+                              the specified CIDRs. For example, a Networks entry of "0.0.0.0/0"
+                              will match both IPv4 and ICMP traffic, while "::/0" will match
+                              both IPv6 and ICMPv6 traffic.
+
                               Each item in Networks should be provided in the CIDR format and should be
                               IPv4 or IPv6, for example "10.0.0.0/8" or "fd00::/8".
 
@@ -588,11 +593,11 @@ spec:
                     action:
                       description: |-
                         Action specifies the effect this rule will have on matching
-                        traffic. Currently the following actions are supported:
+                        traffic. Currently, the following actions are supported:
 
-                        - Accept: Accepts the selected traffic, allowing it into
-                          the destination. No further ClusterNetworkPolicy or
-                          NetworkPolicy rules will be processed.
+                        - Accept: Accepts the selected traffic, including replies to that
+                          traffic and related ICMP traffic. No further ingress
+                          ClusterNetworkPolicy or NetworkPolicy rules will be processed.
 
                           Note: while Accept ensures traffic is accepted by
                           Kubernetes network policy, it is still possible that the

--- a/config/crd/standard/policy.networking.k8s.io_clusternetworkpolicies.yaml
+++ b/config/crd/standard/policy.networking.k8s.io_clusternetworkpolicies.yaml
@@ -75,15 +75,15 @@ spec:
                     action:
                       description: |-
                         Action specifies the effect this rule will have on matching
-                        traffic.  Currently the following actions are supported:
+                        traffic. Currently, the following actions are supported:
 
-                        - Accept: Accepts the selected traffic, allowing it to
-                          egress. No further ClusterNetworkPolicy or NetworkPolicy
-                          rules will be processed.
+                        - Accept: Accepts the selected traffic, including replies to that
+                          traffic and related ICMP traffic. No further egress
+                          ClusterNetworkPolicy or NetworkPolicy rules will be processed
+                          but any ingress rules at the destination do apply.
 
-                        - Deny: Drops the selected traffic. No further
-                          ClusterNetworkPolicy or NetworkPolicy rules will be
-                          processed.
+                        - Deny: Drops the selected traffic. No further ClusterNetworkPolicy or
+                          NetworkPolicy rules will be processed.
 
                         - Pass: Skips all further ClusterNetworkPolicy rules in the
                           current tier for the selected traffic, and passes
@@ -335,6 +335,11 @@ spec:
                               or deny all IPv4 pod-to-pod traffic as well. If you don't want that,
                               add a rule that Passes all pod traffic before the Networks rule.
 
+                              Networks matches both regular IP traffic and ICMP traffic to/from
+                              the specified CIDRs. For example, a Networks entry of "0.0.0.0/0"
+                              will match both IPv4 and ICMP traffic, while "::/0" will match
+                              both IPv6 and ICMPv6 traffic.
+
                               Each item in Networks should be provided in the CIDR format and should be
                               IPv4 or IPv6, for example "10.0.0.0/8" or "fd00::/8".
 
@@ -490,11 +495,11 @@ spec:
                     action:
                       description: |-
                         Action specifies the effect this rule will have on matching
-                        traffic. Currently the following actions are supported:
+                        traffic. Currently, the following actions are supported:
 
-                        - Accept: Accepts the selected traffic, allowing it into
-                          the destination. No further ClusterNetworkPolicy or
-                          NetworkPolicy rules will be processed.
+                        - Accept: Accepts the selected traffic, including replies to that
+                          traffic and related ICMP traffic. No further ingress
+                          ClusterNetworkPolicy or NetworkPolicy rules will be processed.
 
                           Note: while Accept ensures traffic is accepted by
                           Kubernetes network policy, it is still possible that the

--- a/pkg/client/applyconfiguration/apis/v1alpha2/clusternetworkpolicyegresspeer.go
+++ b/pkg/client/applyconfiguration/apis/v1alpha2/clusternetworkpolicyegresspeer.go
@@ -61,6 +61,11 @@ type ClusterNetworkPolicyEgressPeerApplyConfiguration struct {
 	// or deny all IPv4 pod-to-pod traffic as well. If you don't want that,
 	// add a rule that Passes all pod traffic before the Networks rule.
 	//
+	// Networks matches both regular IP traffic and ICMP traffic to/from
+	// the specified CIDRs. For example, a Networks entry of "0.0.0.0/0"
+	// will match both IPv4 and ICMP traffic, while "::/0" will match
+	// both IPv6 and ICMPv6 traffic.
+	//
 	// Each item in Networks should be provided in the CIDR format and should be
 	// IPv4 or IPv6, for example "10.0.0.0/8" or "fd00::/8".
 	//

--- a/pkg/client/applyconfiguration/apis/v1alpha2/clusternetworkpolicyegressrule.go
+++ b/pkg/client/applyconfiguration/apis/v1alpha2/clusternetworkpolicyegressrule.go
@@ -37,15 +37,15 @@ type ClusterNetworkPolicyEgressRuleApplyConfiguration struct {
 	// for any applied policies.
 	Name *string `json:"name,omitempty"`
 	// Action specifies the effect this rule will have on matching
-	// traffic.  Currently the following actions are supported:
+	// traffic. Currently, the following actions are supported:
 	//
-	// - Accept: Accepts the selected traffic, allowing it to
-	// egress. No further ClusterNetworkPolicy or NetworkPolicy
-	// rules will be processed.
+	// - Accept: Accepts the selected traffic, including replies to that
+	// traffic and related ICMP traffic. No further egress
+	// ClusterNetworkPolicy or NetworkPolicy rules will be processed
+	// but any ingress rules at the destination do apply.
 	//
-	// - Deny: Drops the selected traffic. No further
-	// ClusterNetworkPolicy or NetworkPolicy rules will be
-	// processed.
+	// - Deny: Drops the selected traffic. No further ClusterNetworkPolicy or
+	// NetworkPolicy rules will be processed.
 	//
 	// - Pass: Skips all further ClusterNetworkPolicy rules in the
 	// current tier for the selected traffic, and passes

--- a/pkg/client/applyconfiguration/apis/v1alpha2/clusternetworkpolicyingressrule.go
+++ b/pkg/client/applyconfiguration/apis/v1alpha2/clusternetworkpolicyingressrule.go
@@ -35,11 +35,11 @@ type ClusterNetworkPolicyIngressRuleApplyConfiguration struct {
 	// for any applied policies.
 	Name *string `json:"name,omitempty"`
 	// Action specifies the effect this rule will have on matching
-	// traffic. Currently the following actions are supported:
+	// traffic. Currently, the following actions are supported:
 	//
-	// - Accept: Accepts the selected traffic, allowing it into
-	// the destination. No further ClusterNetworkPolicy or
-	// NetworkPolicy rules will be processed.
+	// - Accept: Accepts the selected traffic, including replies to that
+	// traffic and related ICMP traffic. No further ingress
+	// ClusterNetworkPolicy or NetworkPolicy rules will be processed.
 	//
 	// Note: while Accept ensures traffic is accepted by
 	// Kubernetes network policy, it is still possible that the

--- a/site-src/api-overview.md
+++ b/site-src/api-overview.md
@@ -78,9 +78,10 @@ traffic, ClusterNetworkPolicy will enable administrators to set `Pass`,
 be read as-is, i.e. there will not be any implicit isolation effects for the Pods
 selected by the ClusterNetworkPolicy, as opposed to implicit deny NetworkPolicy rules imply.
 
-- **Accept**: Accepts the selected traffic, allowing it into
-  the destination. No further ClusterNetworkPolicy or
-  NetworkPolicy rules will be processed.
+- **Accept**: Accepts the selected traffic, including replies to that
+  traffic and related ICMP traffic (e.g. ICMP errors such as
+  "destination unreachable" or "packet too big"). No further
+  ClusterNetworkPolicy or NetworkPolicy rules will be processed.
 
 - **Deny**: Drops the selected traffic. No further
   ClusterNetworkPolicy or NetworkPolicy rules will be
@@ -119,8 +120,8 @@ before policies with higher priority values in the same tier.
 ### Rules
 
 Each CNP should define at least one `Ingress` or `Egress` relevant in-cluster traffic flow
-along with the associated Action that should occur. In each `gress` rule the user
-should AT THE MINIMUM define an `Action`, and at least one `ClusterNetworkPolicyPeer`.
+along with the associated Action that should occur. In each rule the user
+should *at a minimum* define an `Action`, and at least one peer (`To` or `From` entry).
 Optionally the user may also define select `Protocols` to filter traffic on and also
 a name for each rule to make management and reporting easier for Admins.
 


### PR DESCRIPTION
Clarify that ICMP related packets (such as TOOBIG) are included when accepting traffic.  Tighten up action descriptions and improve formatting in various places.

PR generated with assistance of AI (Claude).