### PR TITLE
chore(docs): add cnp support in calico

### DIFF
--- a/site-src/implementations.md
+++ b/site-src/implementations.md
@@ -8,18 +8,19 @@ implementations, the versions they cover, and documentation to help users get st
 
 ## ClusterNetworkPolicy
 
-Updated: 24-Jan-2026
+Updated: 21-April-2026
 
 - [Kube-network-policies](https://github.com/kubernetes-sigs/kube-network-policies)
 - [Kube-OVN CNI](https://github.com/kubeovn/kube-ovn) (Experimental support)
+- [Calico CNI](https://github.com/projectcalico/calico) (Standard support in Calico v3.32)
 
 ## AdminNetworkPolicy and BaseLineAdminNetworkPolicy (v1alpha1)
 
-Updated: 14-Nov-2024
+Updated: 21-April-2026
 
 - [Kube-network-policies](https://github.com/kubernetes-sigs/kube-network-policies/tree/v0.8.1)
 - [OVN-Kubernetes CNI](https://github.com/ovn-org/ovn-kubernetes/) (Has implemented standard fields of the API + Nodes/Networks in Experimental)
 - [Antrea CNI](https://github.com/antrea-io/antrea/) (Has implemented standard fields of the API)
 - [Kube-OVN CNI](https://github.com/kubeovn/kube-ovn) (Has implemented standard fields of the API)
-- [Calico CNI](https://github.com/projectcalico/calico/issues/7578) (Has implemented standard fields of the API for Admin Network Policy + Networks peer in experimental, Baseline Admin network policy support in progress)
+- [Calico CNI](https://github.com/projectcalico/calico) (Has implemented standard fields of the API + Networks peer in experimental in Calico v3.29, v3.30, and v3.31)
 - [Cilium CNI](https://github.com/cilium/cilium/issues/23380) (tracking issue)


### PR DESCRIPTION
ClusterNetworkPolicy support is introduced in Calico in v3.32 release. Standard fields and some of experimental fields (network peers and named ports) are supported.

