### PR TITLE
Add CEL validation tests for CRDs

### DIFF
--- a/pkg/crdtest/crd_test.go
+++ b/pkg/crdtest/crd_test.go
@@ -60,7 +60,11 @@ func TestValid(t *testing.T) {
 			t.Fatalf("loadYAML(%s) = %v, want nil\nYAML was:\n%s", filePath, err, text)
 		}
 		t.Run(obj.GetName(), func(t *testing.T) {
-			if err := globals.k8sClient.Create(context.Background(), obj); err != nil {
+			err := globals.k8sClient.Create(context.Background(), obj)
+			if err != nil && strings.Contains(e.Name(), ".experimental.yaml") {
+				t.Skipf("Skipping experimental test case on standard CRDs (failed to create: %v)", err)
+			}
+			if err != nil {
 				t.Fatalf("Create() = %v, want nil\nYAML was:\n%s", err, text)
 			}
 			if err := globals.k8sClient.Delete(context.Background(), obj); err != nil {
@@ -87,6 +91,9 @@ func TestInvalid(t *testing.T) {
 		t.Run(obj.GetName(), func(t *testing.T) {
 			err := globals.k8sClient.Create(context.Background(), obj)
 			t.Logf("Create() = %v", err)
+			if err == nil && strings.Contains(e.Name(), ".experimental.yaml") {
+				t.Skip("Skipping experimental test case on standard CRDs (validation rule not present)")
+			}
 			if err == nil {
 				t.Fatalf("Create() = nil, want error\nYAML was:\n%s", text)
 			}

--- a/pkg/crdtest/testdata/invalid/cidr-invalid.yaml
+++ b/pkg/crdtest/testdata/invalid/cidr-invalid.yaml
@@ -1,0 +1,16 @@
+apiVersion: policy.networking.k8s.io/v1alpha2
+kind: ClusterNetworkPolicy
+metadata:
+  name: cidr-invalid
+spec:
+  tier: Admin
+  priority: 10
+  subject:
+    namespaces:
+      matchLabels:
+        kubernetes.io/metadata.name: sensitive-ns
+  egress:
+    - action: Accept
+      to:
+        - networks:
+            - "10.0.0.300/24"

--- a/pkg/crdtest/testdata/invalid/egress-peer-namedport-conflict.experimental.yaml
+++ b/pkg/crdtest/testdata/invalid/egress-peer-namedport-conflict.experimental.yaml
@@ -1,0 +1,19 @@
+# Invalid: destinationNamedPort cannot be used in combination with network (CIDR) egress peers.
+apiVersion: policy.networking.k8s.io/v1alpha2
+kind: ClusterNetworkPolicy
+metadata:
+  name: egress-peer-namedport-conflict
+spec:
+  tier: Admin
+  priority: 10
+  subject:
+    namespaces:
+      matchLabels:
+        kubernetes.io/metadata.name: sensitive-ns
+  egress:
+    - action: Accept
+      to:
+        - networks:
+            - 10.0.0.0/24
+      protocols:
+        - destinationNamedPort: http

--- a/pkg/crdtest/testdata/invalid/port-range-invalid-equal.yaml
+++ b/pkg/crdtest/testdata/invalid/port-range-invalid-equal.yaml
@@ -1,0 +1,24 @@
+# Invalid: The start port must be strictly less than the end port (start == end is invalid).
+apiVersion: policy.networking.k8s.io/v1alpha2
+kind: ClusterNetworkPolicy
+metadata:
+  name: port-range-invalid-equal
+spec:
+  tier: Admin
+  priority: 10
+  subject:
+    namespaces:
+      matchLabels:
+        kubernetes.io/metadata.name: sensitive-ns
+  egress:
+    - action: Accept
+      to:
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: other-ns
+      protocols:
+        - tcp:
+            destinationPort:
+              range:
+                start: 80
+                end: 80

--- a/pkg/crdtest/testdata/invalid/port-range-invalid-greater.yaml
+++ b/pkg/crdtest/testdata/invalid/port-range-invalid-greater.yaml
@@ -1,0 +1,24 @@
+# Invalid: The start port must be strictly less than the end port (start > end is invalid).
+apiVersion: policy.networking.k8s.io/v1alpha2
+kind: ClusterNetworkPolicy
+metadata:
+  name: port-range-invalid-greater
+spec:
+  tier: Admin
+  priority: 10
+  subject:
+    namespaces:
+      matchLabels:
+        kubernetes.io/metadata.name: sensitive-ns
+  egress:
+    - action: Accept
+      to:
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: other-ns
+      protocols:
+        - tcp:
+            destinationPort:
+              range:
+                start: 90
+                end: 80

--- a/pkg/crdtest/testdata/valid/cidr-valid.yaml
+++ b/pkg/crdtest/testdata/valid/cidr-valid.yaml
@@ -1,0 +1,17 @@
+apiVersion: policy.networking.k8s.io/v1alpha2
+kind: ClusterNetworkPolicy
+metadata:
+  name: cidr-valid
+spec:
+  tier: Admin
+  priority: 10
+  subject:
+    namespaces:
+      matchLabels:
+        kubernetes.io/metadata.name: sensitive-ns
+  egress:
+    - action: Accept
+      to:
+        - networks:
+            - "10.0.0.0/24"
+            - "2001:db8::/32"

--- a/pkg/crdtest/testdata/valid/deny-with-named-ports.experimental.yaml
+++ b/pkg/crdtest/testdata/valid/deny-with-named-ports.experimental.yaml
@@ -1,0 +1,23 @@
+apiVersion: policy.networking.k8s.io/v1alpha2
+kind: ClusterNetworkPolicy
+metadata:
+  name: deny-with-named-ports
+spec:
+  tier: Admin
+  priority: 0
+  subject:
+    namespaces:
+      matchLabels:
+        kubernetes.io/metadata.name: sensitive-ns
+  ingress:
+    - action: Deny
+      name: select-all-deny-all
+      from:
+      - pods:
+          namespaceSelector:
+            matchLabels: {}
+          podSelector:
+            matchLabels: {}
+      protocols:
+        - destinationNamedPort: http
+        - destinationNamedPort: monitoring

--- a/pkg/crdtest/testdata/valid/deny-with-ports.yaml
+++ b/pkg/crdtest/testdata/valid/deny-with-ports.yaml
@@ -34,10 +34,9 @@ spec:
         - udp:
             destinationPort:
               number: 9090
-        - destinationNamedPort: http
-        - destinationNamedPort: monitoring
         # Does not exist in the current API, but shows an example of
         # an additional, non-port based extension.
 #       - icmp:
 #           type: 7
 #           code: 3
+

--- a/pkg/crdtest/testdata/valid/port-range-valid.yaml
+++ b/pkg/crdtest/testdata/valid/port-range-valid.yaml
@@ -1,0 +1,23 @@
+apiVersion: policy.networking.k8s.io/v1alpha2
+kind: ClusterNetworkPolicy
+metadata:
+  name: port-range-valid
+spec:
+  tier: Admin
+  priority: 10
+  subject:
+    namespaces:
+      matchLabels:
+        kubernetes.io/metadata.name: sensitive-ns
+  egress:
+    - action: Accept
+      to:
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: other-ns
+      protocols:
+        - tcp:
+            destinationPort:
+              range:
+                start: 80
+                end: 90


### PR DESCRIPTION
Adds test cases under pkg/crdtest/testdata/ to verify CEL validation rules for ClusterNetworkPolicy (v1alpha2):

- Valid/Invalid CIDRs: Verifies IPv4/IPv6 CIDR format validation.
- Port Ranges: Verifies that start < end constraint is enforced (e.g., rejecting 80-80).
- Egress Constraints (Experimental): Verifies mutual exclusion between egress peers (egress.to) and destination named ports.
  - Note: Experimental test cases (named *.experimental.yaml) are automatically skipped by default when running against standard CRDs, as the validation rules are not present.

Fixes: #148 