### PR TITLE
conformance: verify CNP ingress/egress directional isolation

### DIFF
--- a/conformance/tests/admin-network-policy-standard-egress-tcp-rules.go
+++ b/conformance/tests/admin-network-policy-standard-egress-tcp-rules.go
@@ -65,6 +65,27 @@ var CNPAdminTierEgressTCP = suite.ConformanceTest{
 				serverPod.Status.PodIP, int32(80), s.TimeoutConfig, false)
 		})
 
+		t.Run("Should not affect ingress traffic when only egress rules are specified", func(t *testing.T) {
+			// The `egress-tcp` admin CNP declares no ingress rules, so the subject's ingress
+			// must be unaffected. Keep this step after an observed DENY (which proves the
+			// policy is programmed) and before the rule reorderings (so it probes the
+			// declared manifest). Probe sources are picked so no rule can match the reply
+			// path even on stateless dataplanes; hufflepuff's "deny everything else" would.
+			// harry-potter-0 is our server pod in gryffindor namespace
+			serverPod := kubernetes.GetPod(t, s.Client, "network-policy-conformance-gryffindor", "harry-potter-0", s.TimeoutConfig.GetTimeout)
+			// luna-lovegood-0 is our client pod in ravenclaw namespace
+			// ensure ingress is ALLOWED from ravenclaw to gryffindor; matches no ingress rules since there are none
+			kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-ravenclaw", "luna-lovegood-0", "tcp",
+				serverPod.Status.PodIP, int32(80), s.TimeoutConfig, true)
+			// harry-potter-1 is our server pod in gryffindor namespace
+			serverPod = kubernetes.GetPod(t, s.Client, "network-policy-conformance-gryffindor", "harry-potter-1", s.TimeoutConfig.GetTimeout)
+			// draco-malfoy-0 is our client pod in slytherin namespace
+			// ensure ingress is ALLOWED from slytherin to gryffindor, even at port 80
+			// where the egress rule denies the opposite direction
+			kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-slytherin", "draco-malfoy-0", "tcp",
+				serverPod.Status.PodIP, int32(80), s.TimeoutConfig, true)
+		})
+
 		t.Run("Should support an 'deny-egress' policy for TCP protocol; ensure rule ordering is respected", func(t *testing.T) {
 			// This test uses `egress-tcp` admin CNP
 			// luna-lovegood-1 is our server pod in ravenclaw namespace

--- a/conformance/tests/admin-network-policy-standard-ingress-tcp-rules.go
+++ b/conformance/tests/admin-network-policy-standard-ingress-tcp-rules.go
@@ -65,6 +65,27 @@ var CNPAdminTierIngressTCP = suite.ConformanceTest{
 				serverPod.Status.PodIP, int32(8080), s.TimeoutConfig, false)
 		})
 
+		t.Run("Should not affect egress traffic when only ingress rules are specified", func(t *testing.T) {
+			// The `ingress-tcp` admin CNP declares no egress rules, so the subject's egress
+			// must be unaffected. Keep this step after an observed DENY (which proves the
+			// policy is programmed) and before the rule reorderings (so it probes the
+			// declared manifest). Probe targets are picked so no rule can match the reply
+			// path even on stateless dataplanes; hufflepuff's "deny everything else" would.
+			// luna-lovegood-0 is our server pod in ravenclaw namespace
+			serverPod := kubernetes.GetPod(t, s.Client, "network-policy-conformance-ravenclaw", "luna-lovegood-0", s.TimeoutConfig.GetTimeout)
+			// harry-potter-0 is our client pod in gryffindor namespace
+			// ensure egress is ALLOWED from gryffindor to ravenclaw; matches no egress rules since there are none
+			kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-0", "tcp",
+				serverPod.Status.PodIP, int32(80), s.TimeoutConfig, true)
+			// draco-malfoy-0 is our server pod in slytherin namespace
+			serverPod = kubernetes.GetPod(t, s.Client, "network-policy-conformance-slytherin", "draco-malfoy-0", s.TimeoutConfig.GetTimeout)
+			// harry-potter-1 is our client pod in gryffindor namespace
+			// ensure egress is ALLOWED from gryffindor to slytherin, even at port 80
+			// where the ingress rule denies the opposite direction
+			kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "tcp",
+				serverPod.Status.PodIP, int32(80), s.TimeoutConfig, true)
+		})
+
 		t.Run("Should support an 'deny-ingress' policy for TCP protocol; ensure rule ordering is respected", func(t *testing.T) {
 			// This test uses `ingress-tcp` admin CNP
 			// harry-potter-1 is our server pod in gryffindor namespace

--- a/conformance/tests/baseline-admin-network-policy-standard-egress-tcp-rules.go
+++ b/conformance/tests/baseline-admin-network-policy-standard-egress-tcp-rules.go
@@ -65,6 +65,27 @@ var CNPBaselineTierEgressTCP = suite.ConformanceTest{
 				serverPod.Status.PodIP, int32(80), s.TimeoutConfig, false)
 		})
 
+		t.Run("Should not affect ingress traffic when only egress rules are specified", func(t *testing.T) {
+			// The `default` baseline CNP declares no ingress rules, so the subject's ingress
+			// must be unaffected. Keep this step after an observed DENY (which proves the
+			// policy is programmed) and before the rule reorderings (so it probes the
+			// declared manifest). Probe sources are picked so no rule can match the reply
+			// path even on stateless dataplanes; hufflepuff's "deny everything else" would.
+			// harry-potter-0 is our server pod in gryffindor namespace
+			serverPod := kubernetes.GetPod(t, s.Client, "network-policy-conformance-gryffindor", "harry-potter-0", s.TimeoutConfig.GetTimeout)
+			// luna-lovegood-0 is our client pod in ravenclaw namespace
+			// ensure ingress is ALLOWED from ravenclaw to gryffindor; matches no ingress rules since there are none
+			kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-ravenclaw", "luna-lovegood-0", "tcp",
+				serverPod.Status.PodIP, int32(80), s.TimeoutConfig, true)
+			// harry-potter-1 is our server pod in gryffindor namespace
+			serverPod = kubernetes.GetPod(t, s.Client, "network-policy-conformance-gryffindor", "harry-potter-1", s.TimeoutConfig.GetTimeout)
+			// draco-malfoy-0 is our client pod in slytherin namespace
+			// ensure ingress is ALLOWED from slytherin to gryffindor, even at port 80
+			// where the egress rule denies the opposite direction
+			kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-slytherin", "draco-malfoy-0", "tcp",
+				serverPod.Status.PodIP, int32(80), s.TimeoutConfig, true)
+		})
+
 		t.Run("Should support an 'deny-egress' policy for TCP protocol; ensure rule ordering is respected", func(t *testing.T) {
 			// This test uses `default` baseline CNP
 			// luna-lovegood-1 is our server pod in ravenclaw namespace

--- a/conformance/tests/baseline-admin-network-policy-standard-ingress-tcp-rules.go
+++ b/conformance/tests/baseline-admin-network-policy-standard-ingress-tcp-rules.go
@@ -65,6 +65,27 @@ var CNPBaselineTierIngressTCP = suite.ConformanceTest{
 				serverPod.Status.PodIP, int32(8080), s.TimeoutConfig, false)
 		})
 
+		t.Run("Should not affect egress traffic when only ingress rules are specified", func(t *testing.T) {
+			// The `default` baseline CNP declares no egress rules, so the subject's egress
+			// must be unaffected. Keep this step after an observed DENY (which proves the
+			// policy is programmed) and before the rule reorderings (so it probes the
+			// declared manifest). Probe targets are picked so no rule can match the reply
+			// path even on stateless dataplanes; hufflepuff's "deny everything else" would.
+			// luna-lovegood-0 is our server pod in ravenclaw namespace
+			serverPod := kubernetes.GetPod(t, s.Client, "network-policy-conformance-ravenclaw", "luna-lovegood-0", s.TimeoutConfig.GetTimeout)
+			// harry-potter-0 is our client pod in gryffindor namespace
+			// ensure egress is ALLOWED from gryffindor to ravenclaw; matches no egress rules since there are none
+			kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-0", "tcp",
+				serverPod.Status.PodIP, int32(80), s.TimeoutConfig, true)
+			// draco-malfoy-0 is our server pod in slytherin namespace
+			serverPod = kubernetes.GetPod(t, s.Client, "network-policy-conformance-slytherin", "draco-malfoy-0", s.TimeoutConfig.GetTimeout)
+			// harry-potter-1 is our client pod in gryffindor namespace
+			// ensure egress is ALLOWED from gryffindor to slytherin, even at port 80
+			// where the ingress rule denies the opposite direction
+			kubernetes.PokeServer(t, s.ClientSet, &s.KubeConfig, "network-policy-conformance-gryffindor", "harry-potter-1", "tcp",
+				serverPod.Status.PodIP, int32(80), s.TimeoutConfig, true)
+		})
+
 		t.Run("Should support an 'deny-ingress' policy for TCP protocol; ensure rule ordering is respected", func(t *testing.T) {
 			// This test uses `default` baseline CNP
 			// harry-potter-1 is our server pod in gryffindor namespace


### PR DESCRIPTION
#### What type of PR is this?

/kind test

#### What this PR does / why we need it:

The existing `ClusterNetworkPolicy` ingress/egress rule conformance tests only probe
traffic in the *same* direction as the rules under test — the ingress-rule tests probe
traffic toward the subject, the egress-rule tests probe traffic from the subject. They
never verify the API's directional-independence guarantee:

> CNPs with no egress rules do not affect egress traffic
> CNPs with no ingress rules do not affect ingress traffic

So an implementation with a cross-direction side-effect (e.g. one that treats "the
subject is selected by a policy" as "isolate the pod in both directions", the way plain
NetworkPolicy's `policyTypes` works) could pass the entire suite while silently breaking
the subject's traffic in the *unspecified* direction.

This PR closes that gap. For both the Admin and Baseline tiers it adds:
- an **ingress-only** CNP, and verifies the subject's **egress is unaffected**; and
- an **egress-only** CNP, and verifies the subject's **ingress is unaffected**.

Each test first asserts a positive control (the one-directional rule is actually
enforced) so the isolation assertions are meaningful, then probes the opposite
direction to namespaces the policy does not reference.

New tests (all gated on the standard `ClusterNetworkPolicy` feature):
- `CNPAdminTierIngressRulesEgressUnaffected`
- `CNPAdminTierEgressRulesIngressUnaffected`
- `CNPBaselineTierIngressRulesEgressUnaffected`
- `CNPBaselineTierEgressRulesIngressUnaffected`

#### Which issue(s) this PR fixes:

Fixes #103

#### Special notes for your reviewer:

- The isolation probes deliberately target **ravenclaw** and **hufflepuff** —
  namespaces the policy never references — so the connection's reply path cannot be
  affected by the rule under test and confound the result (e.g. a `deny-to-slytherin`
  egress rule could affect the reply path of an inbound connection *from* slytherin on
  a stateless dataplane). Using unreferenced peers isolates the property cleanly.
- I implemented these as **dedicated tests + minimal single-direction manifests**
  rather than appending probes to the existing `*-rules.go` tests, because those tests
  mutate their policy mid-run (`PatchClusterNetworkPolicy` rule-reordering), which would
  make appended probes order-dependent. Happy to fold them into the existing files
  instead if you'd prefer — the probe logic is identical.
- Scope: TCP only, since directional isolation is protocol-independent. Glad to add
  UDP/SCTP variants if you'd like them.
- No API or codegen changes — purely additive conformance tests.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```