### PR TITLE
conformance: add --dry-run flag to skip dataplane probes

### DIFF
--- a/conformance/conformance_profile_test.go
+++ b/conformance/conformance_profile_test.go
@@ -100,8 +100,8 @@ func TestConformanceProfiles(t *testing.T) {
 }
 
 func testConformance(t *testing.T) {
-	t.Logf("Running conformance profile tests with cleanup: %t\n debug: %t\n enable all features: %t \n supported features: [%v]\n exempt features: [%v]\n conformance profiles: [%v]",
-		*flags.CleanupBaseResources, *flags.ShowDebug, *flags.EnableAllSupportedFeatures, *flags.SupportedFeatures, *flags.ExemptFeatures, *flags.ConformanceProfiles)
+	t.Logf("Running conformance profile tests with cleanup: %t\n debug: %t\n enable all features: %t \n dry-run: %t \n supported features: [%v]\n exempt features: [%v]\n conformance profiles: [%v]",
+		*flags.CleanupBaseResources, *flags.ShowDebug, *flags.EnableAllSupportedFeatures, *flags.DryRun, *flags.SupportedFeatures, *flags.ExemptFeatures, *flags.ConformanceProfiles)
 
 	cSuite, err := suite.NewConformanceProfileTestSuite(
 		suite.ConformanceProfileOptions{
@@ -110,6 +110,7 @@ func testConformance(t *testing.T) {
 				ClientSet:                  clientSet,
 				KubeConfig:                 *cfg,
 				Debug:                      *flags.ShowDebug,
+				DryRun:                     *flags.DryRun,
 				CleanupBaseResources:       *flags.CleanupBaseResources,
 				SupportedFeatures:          supportedFeatures,
 				ExemptFeatures:             exemptFeatures,
@@ -127,6 +128,10 @@ func testConformance(t *testing.T) {
 	report, err := cSuite.Report()
 	if err != nil {
 		t.Fatalf("error generating conformance profile report: %v", err)
+	}
+	if *flags.DryRun {
+		t.Log("WARNING: --dry-run was enabled; connectivity was NOT verified. " +
+			"This report reflects only manifest/schema validity and test setup, and MUST NOT be submitted as a conformance result.")
 	}
 	writeReport(t.Logf, *report, *flags.ReportOutput)
 }

--- a/conformance/conformance_test.go
+++ b/conformance/conformance_test.go
@@ -59,14 +59,15 @@ func TestConformance(t *testing.T) {
 	supportedFeatures := suite.ParseSupportedFeatures(*flags.SupportedFeatures)
 	exemptFeatures := suite.ParseSupportedFeatures(*flags.ExemptFeatures)
 
-	t.Logf("Running conformance tests with cleanup: %t\n debug: %t\n enable all features: %t \n supported features: [%v]\n exempt features: [%v]",
-		*flags.CleanupBaseResources, *flags.ShowDebug, *flags.EnableAllSupportedFeatures, *flags.SupportedFeatures, *flags.ExemptFeatures)
+	t.Logf("Running conformance tests with cleanup: %t\n debug: %t\n enable all features: %t \n dry-run: %t \n supported features: [%v]\n exempt features: [%v]",
+		*flags.CleanupBaseResources, *flags.ShowDebug, *flags.EnableAllSupportedFeatures, *flags.DryRun, *flags.SupportedFeatures, *flags.ExemptFeatures)
 
 	cSuite := suite.New(suite.Options{
 		Client:                     c,
 		ClientSet:                  clientset,
 		KubeConfig:                 *cfg,
 		Debug:                      *flags.ShowDebug,
+		DryRun:                     *flags.DryRun,
 		CleanupBaseResources:       *flags.CleanupBaseResources,
 		SupportedFeatures:          supportedFeatures,
 		ExemptFeatures:             exemptFeatures,

--- a/conformance/utils/flags/flag.go
+++ b/conformance/utils/flags/flag.go
@@ -29,6 +29,7 @@ var (
 	SupportedFeatures          = flag.String("supported-features", "", "Supported features included in conformance tests suites")
 	ExemptFeatures             = flag.String("exempt-features", "", "Exempt Features excluded from conformance tests suites")
 	EnableAllSupportedFeatures = flag.Bool("all-features", false, "Whether to enable all supported features for conformance tests")
+	DryRun                     = flag.Bool("dry-run", false, "Apply manifests and run all test logic but skip the dataplane connectivity probes. Validates suite/manifest stability against a cluster that has the CRDs installed but no NetworkPolicy implementation")
 )
 
 // Required for Conformance Profiles

--- a/conformance/utils/kubernetes/helper.go
+++ b/conformance/utils/kubernetes/helper.go
@@ -30,6 +30,20 @@ var (
 	numStatufulSetReplicas int32 = 2
 )
 
+// dryRun, when true, makes PokeServer skip the actual dataplane connectivity
+// probe and its assertion. It is set once via SetDryRun before any test runs,
+// so reads during the (possibly parallel) test run are race-free.
+var dryRun bool
+
+// SetDryRun toggles dry-run mode for connectivity probes. In dry-run mode
+// PokeServer logs the probe it would have performed and returns without
+// contacting the dataplane. This lets the suite validate manifests, setup and
+// teardown against a cluster that has the CRDs installed but no NetworkPolicy
+// implementation (for example, upstream CI on a vanilla cluster).
+func SetDryRun(d bool) {
+	dryRun = d
+}
+
 // RunCommandFromPod is a utility function that runs kubectl exec command on the Pod specified and returns the result.
 func RunCommandFromPod(client k8sclient.Interface, kubeConfig *rest.Config, podNamespace, podName string, cmd []string) (stdout string, stderr string, err error) {
 	// TODO(dyanngg): find a better way to derive container name
@@ -67,6 +81,11 @@ func RunCommandFromPod(client k8sclient.Interface, kubeConfig *rest.Config, podN
 // and timing out after TimeoutConfig.PokeTimeout. If eventually the expected result is met, it verifies the connectivity
 // once more to rule out transient cases.
 func PokeServer(t *testing.T, client k8sclient.Interface, kubeConfig *rest.Config, clientNamespace, clientPod, protocol, targetHost string, targetPort int32, timeoutConfig config.TimeoutConfig, shouldConnect bool) {
+	if dryRun {
+		t.Logf("[dry-run] skipping connectivity probe from %s/%s to %s:%d (%s), expected shouldConnect=%t",
+			clientNamespace, clientPod, targetHost, targetPort, protocol, shouldConnect)
+		return
+	}
 	require.Eventually(t, func() bool {
 		return doPokeServer(t, client, kubeConfig, clientNamespace, clientPod, protocol, targetHost, targetPort, timeoutConfig.RequestTimeout, shouldConnect)
 	}, timeoutConfig.PokeTimeout, timeoutConfig.PokeInterval)

--- a/conformance/utils/kubernetes/helper_test.go
+++ b/conformance/utils/kubernetes/helper_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"sigs.k8s.io/network-policy-api/conformance/utils/config"
+)
+
+// TestPokeServerDryRun verifies that, in dry-run mode, PokeServer short-circuits
+// before contacting the dataplane. It is deliberately called with a nil client
+// and nil kubeConfig: if the probe were actually attempted it would panic or
+// fail, so a passing subtest proves no dataplane access occurred.
+func TestPokeServerDryRun(t *testing.T) {
+	SetDryRun(true)
+	defer SetDryRun(false)
+
+	ok := t.Run("probe is a no-op in dry-run mode", func(st *testing.T) {
+		PokeServer(st, nil, nil, "client-ns", "client-pod", "tcp", "192.0.2.1", 80, config.TimeoutConfig{}, false)
+	})
+	assert.True(t, ok, "dry-run PokeServer must not fail or contact the dataplane")
+}

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -41,6 +41,7 @@ type ConformanceTestSuite struct {
 	KubeConfig                rest.Config
 	Debug                     bool
 	Cleanup                   bool
+	DryRun                    bool
 	BaseManifests             string
 	HostNetworkPortRangeStart int
 	HostNetworkPortRangeEnd   int
@@ -58,6 +59,7 @@ type Options struct {
 	ClientSet       k8sclient.Interface
 	KubeConfig      rest.Config
 	Debug           bool
+	DryRun          bool
 	BaseManifests   string
 	NamespaceLabels map[string]string
 	// HostNetworkPortRangeStart and HostNetworkPortRangeEnd allows using a custom port range for host-networked pods.
@@ -108,6 +110,7 @@ func New(s Options) *ConformanceTestSuite {
 		KubeConfig:                s.KubeConfig,
 		Debug:                     s.Debug,
 		Cleanup:                   s.CleanupBaseResources,
+		DryRun:                    s.DryRun,
 		BaseManifests:             s.BaseManifests,
 		HostNetworkPortRangeStart: s.HostNetworkPortRangeStart,
 		HostNetworkPortRangeEnd:   s.HostNetworkPortRangeEnd,
@@ -131,6 +134,15 @@ func New(s Options) *ConformanceTestSuite {
 // Setup ensures the base resources required for conformance tests are installed
 // in the cluster. It also ensures that all relevant resources are ready.
 func (suite *ConformanceTestSuite) Setup(t *testing.T) {
+	// Propagate dry-run mode to the connectivity probe helper before any test
+	// runs. In dry-run mode PokeServer becomes a no-op, so the suite still
+	// applies all manifests and exercises setup/teardown but skips the
+	// dataplane probes (which require a NetworkPolicy implementation).
+	kubernetes.SetDryRun(suite.DryRun)
+	if suite.DryRun {
+		t.Log("Dry-run mode enabled: manifests will be applied and resources reconciled, but connectivity probes will be skipped")
+	}
+
 	suite.Applier.FS = suite.FS
 
 	if suite.HostNetworkPortRangeStart != 0 && suite.HostNetworkPortRangeEnd == 0 ||


### PR DESCRIPTION
When set, the suite applies every manifest and runs all test setup/teardown and API-level logic, but PokeServer skips the dataplane connectivity probe and its assertion. This lets conformance run against a cluster that has the CRDs installed but no NetworkPolicy implementation (e.g. a vanilla kind cluster), catching regressions in the tests, manifests, and CRD schemas independently of any implementation.

The flag threads from flags to suite.Options to ConformanceTestSuite and is propagated to the probe helper via kubernetes.SetDryRun() in Setup, so it applies to both the standard and profile entrypoints. A conformance report generated with --dry-run logs a warning that it must not be submitted. Includes a unit test for the dry-run short-circuit.

Fixes #107