### PR TITLE
apis: fix DomainName validation pattern to reject invalid characters

### DIFF
--- a/apis/v1alpha1/adminnetworkpolicy_types.go
+++ b/apis/v1alpha1/adminnetworkpolicy_types.go
@@ -287,7 +287,7 @@ type AdminNetworkPolicyEgressPeer struct {
 //     "latest.blog.kubernetes.io" match, however "kubernetes.io", and
 //     "wikipedia.org" do not.
 //
-// +kubebuilder:validation:Pattern=`^(\*\.)?([a-zA-z0-9]([-a-zA-Z0-9_]*[a-zA-Z0-9])?\.)+[a-zA-z0-9]([-a-zA-Z0-9_]*[a-zA-Z0-9])?\.?$`
+// +kubebuilder:validation:Pattern=`^(\*\.)?([a-zA-Z0-9]([-a-zA-Z0-9_]*[a-zA-Z0-9])?\.)+[a-zA-Z0-9]([-a-zA-Z0-9_]*[a-zA-Z0-9])?\.?$`
 type DomainName string
 
 const (

--- a/apis/v1alpha2/clusternetworkpolicy_types.go
+++ b/apis/v1alpha2/clusternetworkpolicy_types.go
@@ -551,5 +551,5 @@ type CIDR string
 //     "latest.blog.kubernetes.io" match, however "kubernetes.io", and
 //     "wikipedia.org" do not.
 //
-// +kubebuilder:validation:Pattern=`^(\*\.)?([a-zA-z0-9]([-a-zA-Z0-9_]*[a-zA-Z0-9])?\.)+[a-zA-z0-9]([-a-zA-Z0-9_]*[a-zA-Z0-9])?\.?$`
+// +kubebuilder:validation:Pattern=`^(\*\.)?([a-zA-Z0-9]([-a-zA-Z0-9_]*[a-zA-Z0-9])?\.)+[a-zA-Z0-9]([-a-zA-Z0-9_]*[a-zA-Z0-9])?\.?$`
 type DomainName string

--- a/config/crd/experimental/policy.networking.k8s.io_clusternetworkpolicies.yaml
+++ b/config/crd/experimental/policy.networking.k8s.io_clusternetworkpolicies.yaml
@@ -309,7 +309,7 @@ spec:
                                     "www.kubernetes.io", "blog.kubernetes.io", and
                                     "latest.blog.kubernetes.io" match, however "kubernetes.io", and
                                     "wikipedia.org" do not.
-                              pattern: ^(\*\.)?([a-zA-z0-9]([-a-zA-Z0-9_]*[a-zA-Z0-9])?\.)+[a-zA-z0-9]([-a-zA-Z0-9_]*[a-zA-Z0-9])?\.?$
+                              pattern: ^(\*\.)?([a-zA-Z0-9]([-a-zA-Z0-9_]*[a-zA-Z0-9])?\.)+[a-zA-Z0-9]([-a-zA-Z0-9_]*[a-zA-Z0-9])?\.?$
                               type: string
                             maxItems: 25
                             minItems: 1


### PR DESCRIPTION
The DomainName validation pattern used the character class `[a-zA-z0-9]`.

This is an unintentional typo: the same pattern already uses the correct `[a-zA-Z0-9]` in its other character classes. Correct the two occurrences in the v1alpha1 and v1alpha2 DomainName types and regenerate the CRDs.

The newly-rejected characters are not valid in domain names, so no valid DomainName value is affected.