### PR TITLE
Make NamedPort experimental again

### DIFF
--- a/apis/v1alpha2/clusternetworkpolicy_types.go
+++ b/apis/v1alpha2/clusternetworkpolicy_types.go
@@ -451,6 +451,7 @@ type ClusterNetworkPolicyProtocol struct {
 	// ContainerPort name. You can't use this in a rule that targets resources
 	// without named ports (e.g. Nodes or Networks).
 	//
+	// <network-policy-api:experimental>
 	// +optional
 	DestinationNamedPort string `json:"destinationNamedPort,omitempty"`
 }

--- a/config/crd/experimental/policy.networking.k8s.io_clusternetworkpolicies.yaml
+++ b/config/crd/experimental/policy.networking.k8s.io_clusternetworkpolicies.yaml
@@ -119,6 +119,8 @@ spec:
                               DestinationNamedPort selects a destination port on a pod based on the
                               ContainerPort name. You can't use this in a rule that targets resources
                               without named ports (e.g. Nodes or Networks).
+
+                              <network-policy-api:experimental>
                             type: string
                           sctp:
                             description: SCTP specific protocol matches.
@@ -822,6 +824,8 @@ spec:
                               DestinationNamedPort selects a destination port on a pod based on the
                               ContainerPort name. You can't use this in a rule that targets resources
                               without named ports (e.g. Nodes or Networks).
+
+                              <network-policy-api:experimental>
                             type: string
                           sctp:
                             description: SCTP specific protocol matches.

--- a/config/crd/standard/policy.networking.k8s.io_clusternetworkpolicies.yaml
+++ b/config/crd/standard/policy.networking.k8s.io_clusternetworkpolicies.yaml
@@ -114,12 +114,6 @@ spec:
                         maxProperties: 1
                         minProperties: 1
                         properties:
-                          destinationNamedPort:
-                            description: |-
-                              DestinationNamedPort selects a destination port on a pod based on the
-                              ContainerPort name. You can't use this in a rule that targets resources
-                              without named ports (e.g. Nodes or Networks).
-                            type: string
                           sctp:
                             description: SCTP specific protocol matches.
                             minProperties: 1
@@ -719,12 +713,6 @@ spec:
                         maxProperties: 1
                         minProperties: 1
                         properties:
-                          destinationNamedPort:
-                            description: |-
-                              DestinationNamedPort selects a destination port on a pod based on the
-                              ContainerPort name. You can't use this in a rule that targets resources
-                              without named ports (e.g. Nodes or Networks).
-                            type: string
                           sctp:
                             description: SCTP specific protocol matches.
                             minProperties: 1

--- a/pkg/client/applyconfiguration/apis/v1alpha2/clusternetworkpolicyprotocol.go
+++ b/pkg/client/applyconfiguration/apis/v1alpha2/clusternetworkpolicyprotocol.go
@@ -33,6 +33,8 @@ type ClusterNetworkPolicyProtocolApplyConfiguration struct {
 	// DestinationNamedPort selects a destination port on a pod based on the
 	// ContainerPort name. You can't use this in a rule that targets resources
 	// without named ports (e.g. Nodes or Networks).
+	//
+	// <network-policy-api:experimental>
 	DestinationNamedPort *string `json:"destinationNamedPort,omitempty"`
 }
 


### PR DESCRIPTION
We lost the experimental tag during the port matching rework 3a7295a
https://github.com/kubernetes-sigs/network-policy-api/commit/3a7295af7dadcadcaaea18d4b95f9e840bbf234a#diff-623dc90cdaee94844b5b9046b49c6ad6200409f4f9e182a2c1740dcea62088c4L343