### PR TITLE
conformance: derive report API version from installed CRDs

### DIFF
--- a/conformance/conformance_profile_test.go
+++ b/conformance/conformance_profile_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"testing"
 
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -70,6 +71,11 @@ func TestConformanceProfiles(t *testing.T) {
 	err = api.Install(c.Scheme())
 	if err != nil {
 		t.Fatalf("Error installing api scheme: %v", err)
+	}
+
+	err = apiextensionsv1.AddToScheme(c.Scheme())
+	if err != nil {
+		t.Fatalf("Error installing apiextensions scheme: %v", err)
 	}
 
 	// standard conformance flags

--- a/conformance/utils/suite/conformance_suite.go
+++ b/conformance/utils/suite/conformance_suite.go
@@ -17,6 +17,7 @@ limitations under the License.
 package suite
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -24,11 +25,13 @@ import (
 	"testing"
 	"time"
 
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	confv1a1 "sigs.k8s.io/network-policy-api/conformance/apis/v1alpha1"
 	"sigs.k8s.io/network-policy-api/conformance/utils/config"
+	"sigs.k8s.io/network-policy-api/pkg/consts"
 )
 
 type ConformanceProfileTestSuite struct {
@@ -41,6 +44,12 @@ type ConformanceProfileTestSuite struct {
 	// conformanceProfiles is a compiled list of profiles to check
 	// conformance against.
 	conformanceProfiles sets.Set[ConformanceProfileName]
+
+	// apiVersion is the version of the Network Policy API CRDs installed in
+	// the cluster when the suite was created, as recorded by their
+	// bundle-version annotation, and is the version the report certifies
+	// against.
+	apiVersion string
 
 	// running indicates whether the test suite is currently running
 	running bool
@@ -118,6 +127,16 @@ func NewConformanceProfileTestSuite(s ConformanceProfileOptions) (*ConformancePr
 			}
 		}
 	}
+	installedCRDs := &apiextensionsv1.CustomResourceDefinitionList{}
+	if err := s.Client.List(context.TODO(), installedCRDs); err != nil {
+		return nil, fmt.Errorf("failed to list installed CRDs: %w", err)
+	}
+	version, _, err := getAPIVersionAndChannel(installedCRDs.Items)
+	if err != nil {
+		return nil, err
+	}
+	suite.apiVersion = version
+
 	suite.ConformanceTestSuite = *New(s.Options)
 	return suite, nil
 }
@@ -207,13 +226,9 @@ func (suite *ConformanceProfileTestSuite) Report() (*confv1a1.ConformanceReport,
 			APIVersion: "policy.networking.k8s.io/v1alpha1",
 			Kind:       "ConformanceReport",
 		},
-		Date:           time.Now().Format(time.RFC3339),
-		Implementation: suite.implementation,
-		// TODO: Need to add logic to how we can determine against which API version test was run against
-		// Shouldn't this be same as Implementation.Version?
-		// Currently pinning it to the version where profiles are going to be introduced in
-		// We might need to bump this with every version we release
-		NetworkPolicyV2APIVersion: "v0.1.2",
+		Date:                      time.Now().Format(time.RFC3339),
+		Implementation:            suite.implementation,
+		NetworkPolicyV2APIVersion: suite.apiVersion,
 		ProfileReports:            profileReports.list(),
 	}, nil
 }
@@ -266,4 +281,37 @@ func ParseConformanceProfiles(p string) sets.Set[ConformanceProfileName] {
 		res.Insert(ConformanceProfileName(value))
 	}
 	return res
+}
+
+// getAPIVersionAndChannel iterates over all the CRDs installed in the cluster
+// and checks the version and channel annotations. In case the annotations are
+// not found or there are CRDs with different versions or channels, an error is
+// returned.
+func getAPIVersionAndChannel(crds []apiextensionsv1.CustomResourceDefinition) (version string, channel string, err error) {
+	for _, crd := range crds {
+		v, okv := crd.Annotations[consts.BundleVersionAnnotation]
+		c, okc := crd.Annotations[consts.ChannelAnnotation]
+		if !okv && !okc {
+			continue
+		}
+		if !okv || !okc {
+			return "", "", errors.New("detected CRDs with partial version and channel annotations")
+		}
+		if version != "" && v != version {
+			return "", "", errors.New("multiple Network Policy API CRDs versions detected")
+		}
+		if channel != "" && c != channel {
+			return "", "", errors.New("multiple Network Policy API CRDs channels detected")
+		}
+		version = v
+		channel = c
+	}
+	if version == "" || channel == "" {
+		return "", "", errors.New("no Network Policy API CRDs with the proper annotations found in the cluster")
+	}
+	if version != consts.BundleVersion {
+		return "", "", errors.New("the installed CRDs version is different from the suite version")
+	}
+
+	return version, channel, nil
 }

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package consts
+
+const (
+	// BundleVersionAnnotation is the annotation key used in the Network Policy API
+	// CRDs to specify the installed Network Policy API version.
+	BundleVersionAnnotation = "policy.networking.k8s.io/bundle-version"
+
+	// ChannelAnnotation is the annotation key used in the Network Policy API
+	// CRDs to specify the installed Network Policy API channel.
+	ChannelAnnotation = "policy.networking.k8s.io/channel"
+
+	// BundleVersion is the value used for the "policy.networking.k8s.io/bundle-version"
+	// annotation. This value must be updated during the release process.
+	BundleVersion = "v0.2.0"
+
+	// ApprovalLink is the value used for the "api-approved.kubernetes.io"
+	// annotation. This value must be updated during the release process.
+	ApprovalLink = "https://github.com/kubernetes-sigs/network-policy-api/pull/347"
+)

--- a/pkg/generator/main.go
+++ b/pkg/generator/main.go
@@ -25,15 +25,8 @@ import (
 	"sigs.k8s.io/controller-tools/pkg/loader"
 	"sigs.k8s.io/controller-tools/pkg/markers"
 	"sigs.k8s.io/yaml"
-)
 
-const (
-	bundleVersionAnnotation = "policy.networking.k8s.io/bundle-version"
-	channelAnnotation       = "policy.networking.k8s.io/channel"
-
-	// These values must be updated during the release process
-	bundleVersion = "v0.2.0"
-	approvalLink  = "https://github.com/kubernetes-sigs/network-policy-api/pull/347"
+	"sigs.k8s.io/network-policy-api/pkg/consts"
 )
 
 var standardKinds = map[string]bool{
@@ -96,9 +89,9 @@ func main() {
 			if crdRaw.ObjectMeta.Annotations == nil {
 				crdRaw.ObjectMeta.Annotations = map[string]string{}
 			}
-			crdRaw.ObjectMeta.Annotations[bundleVersionAnnotation] = bundleVersion
-			crdRaw.ObjectMeta.Annotations[channelAnnotation] = channel
-			crdRaw.ObjectMeta.Annotations[apiext.KubeAPIApprovedAnnotation] = approvalLink
+			crdRaw.ObjectMeta.Annotations[consts.BundleVersionAnnotation] = consts.BundleVersion
+			crdRaw.ObjectMeta.Annotations[consts.ChannelAnnotation] = channel
+			crdRaw.ObjectMeta.Annotations[apiext.KubeAPIApprovedAnnotation] = consts.ApprovalLink
 
 			// Prevent the top level metadata for the CRD to be generated regardless of the intention in the arguments
 			crd.FixTopLevelMetadata(crdRaw)


### PR DESCRIPTION
The conformance profiles report hardcoded `networkPolicyV2APIVersion` to `v0.1.2`, so any report generated since then misstates the API version it certifies: the in-tree CRDs are stamped `v0.2.0`.

This review moves the release-bumped annotation values from `pkg/generator` into an importable `pkg/consts`, and resolve the reported version at suite construction time by reading the `policy.networking.k8s.io/bundle-version` annotation from the CRDs installed in the cluster, following the gateway-api precedent. Missing, partial, or inconsistent annotations, or an installed version that does not match the suite's own bundle version, now fail the profiles suite early with a clear error instead of producing a report that misidentifies the certified API version.

Generated CRD output is unchanged.